### PR TITLE
Added input url and address with port support

### DIFF
--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -53,8 +53,8 @@ func readFlags() error {
 		flagSet.StringVar(&cfgFile, "config", "", "path to the tlsx configuration file"),
 		flagSet.IntVar(&options.Timeout, "timeout", 5, "tls connection timeout in seconds"),
 		flagSet.IntVarP(&options.Concurrency, "concurrency", "c", 300, "number of concurrent threads to process"),
-		flagSet.StringVar(&options.MinVersion, "min-version", "", "minimum tls version to accept (tls10,tls11,tls12,tls13)"),
-		flagSet.StringVar(&options.MaxVersion, "max-version", "", "maximum tls version to accept (tls10,tls11,tls12,tls13)"),
+		flagSet.StringVar(&options.MinVersion, "min-version", "", "minimum tls version to accept (ssl30,tls10,tls11,tls12,tls13)"),
+		flagSet.StringVar(&options.MaxVersion, "max-version", "", "maximum tls version to accept (ssl30,tls10,tls11,tls12,tls13)"),
 		flagSet.BoolVarP(&options.CertsOnly, "pre-handshake", "ps", false, "enable pre-handshake tls connection (early termination) using ztls"),
 		flagSet.BoolVar(&options.Zcrypto, "ztls", false, "use zmap/zcrypto instead of crypto/tls for tls connection"),
 	)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,7 +3,9 @@ package runner
 import (
 	"bufio"
 	"net"
+	"net/url"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -149,8 +151,36 @@ func (r *Runner) processInputItem(input string, inputs chan taskInput) {
 		}
 	} else {
 		// Normal input
-		for _, port := range r.options.Ports {
-			inputs <- taskInput{host: input, port: port}
+		host, customPort := r.getHostPortFromInput(input)
+		if customPort == "" {
+			for _, port := range r.options.Ports {
+				inputs <- taskInput{host: host, port: port}
+			}
+		} else {
+			inputs <- taskInput{host: host, port: customPort}
 		}
 	}
+}
+
+// getHostPortFromInput returns host and optionally port from input.
+// If no ports are found, port field is left blank and user specified ports
+// are used.
+func (r *Runner) getHostPortFromInput(input string) (string, string) {
+	host := input
+
+	if strings.Contains(input, "://") {
+		if parsed, err := url.Parse(input); err != nil {
+			return "", ""
+		} else {
+			host = parsed.Host
+		}
+	}
+	if strings.Contains(host, ":") {
+		if host, port, err := net.SplitHostPort(host); err != nil {
+			return "", ""
+		} else {
+			return host, port
+		}
+	}
+	return host, ""
 }


### PR DESCRIPTION
Closes #18 by adding support for URL and Address with Port inputs

```console
./tlsx -u example.com,example.com:443,https://example.com,https://example.com:443
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\	v0.0.1

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
example.com:443
example.com:443
example.com:443
example.com:443
```