### PR TITLE
Fix certificate NotBefore field in json output

### DIFF
--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -169,7 +169,7 @@ func convertCertificateToResponse(cert *x509.Certificate) clients.CertificateRes
 	response := clients.CertificateResponse{
 		SubjectAN:  cert.DNSNames,
 		Emails:     cert.EmailAddresses,
-		NotBefore:  cert.NotAfter,
+		NotBefore:  cert.NotBefore,
 		NotAfter:   cert.NotAfter,
 		Expired:    clients.IsExpired(cert.NotAfter),
 		SelfSigned: clients.IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId),

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -189,7 +189,7 @@ func convertCertificateToResponse(cert *x509.Certificate) clients.CertificateRes
 	return clients.CertificateResponse{
 		SubjectAN:  cert.DNSNames,
 		Emails:     cert.EmailAddresses,
-		NotBefore:  cert.NotAfter,
+		NotBefore:  cert.NotBefore,
 		NotAfter:   cert.NotAfter,
 		Expired:    clients.IsExpired(cert.NotAfter),
 		SelfSigned: clients.IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId),


### PR DESCRIPTION
When printing the TLS infos as json (`tlsx -u example.com -silent -json | jq .`) the `not-before` field contains the wrong value (the value of `NotAfter`).

This fix replaces the field `cert.NotAfter` with the correct `cert.NotBefore` field.

Output tlsx:
```bash
# tlsx -u example.com -silent -json | jq '.'                      
...
  "not-before": "2023-03-14T23:59:59Z",
  "not-after": "2023-03-14T23:59:59Z",
...
```

Output OpenSSL:
```bash
# openssl s_client -connect example.com:443 2>/dev/null | openssl x509 -noout -dates
notBefore=Mar 14 00:00:00 2022 GMT
notAfter=Mar 14 23:59:59 2023 GMT
```