### PR TITLE
Adding jarm fingerprinting

### DIFF
--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -49,7 +49,7 @@ func readFlags() error {
 		flagSet.StringSliceVarP(&options.Ports, "port", "p", nil, "target port to connect (default 443)", goflags.FileCommaSeparatedStringSliceOptions),
 	)
 
-	flagSet.CreateGroup("scan-mode", "SCAN-MODE",
+	flagSet.CreateGroup("scan-mode", "Scan-Mode",
 		flagSet.StringVarP(&options.ScanMode, "scan-mode", "sm", "", "tls connection mode to use (ctls, ztls, auto) (default ctls)"),
 		flagSet.BoolVarP(&options.CertsOnly, "pre-handshake", "ps", false, "enable pre-handshake tls connection (early termination) using ztls"),
 	)
@@ -63,6 +63,7 @@ func readFlags() error {
 		flagSet.BoolVarP(&options.Expired, "expired", "ex", false, "display validity status of certificate"),
 		flagSet.BoolVarP(&options.SelfSigned, "self-signed", "ss", false, "display status of self-signed certificate"),
 		flagSet.StringVar(&options.Hash, "hash", "", "display certificate fingerprint hashes (md5,sha1,sha256)"),
+		flagSet.BoolVar(&options.Jarm, "jarm", false, "display jarm fingerprint hash"),
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",
@@ -77,7 +78,7 @@ func readFlags() error {
 		flagSet.BoolVar(&options.VerifyServerCertificate, "verify-cert", false, "enable verification of server certificate"),
 	)
 
-	flagSet.CreateGroup("optimizations", "OPTIMIZATIONS",
+	flagSet.CreateGroup("optimizations", "Optimizations",
 		flagSet.IntVarP(&options.Concurrency, "concurrency", "c", 300, "number of concurrent threads to process"),
 		flagSet.IntVar(&options.Timeout, "timeout", 5, "tls connection timeout in seconds"),
 	)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/projectdiscovery/mapcidr v1.0.0
 	github.com/rs/xid v1.4.0
 	github.com/zmap/zcrypto v0.0.0-20220605182715-4dfcec6e9a8c
-	go.uber.org/multierr v1.8.0
 )
 
 require (
@@ -41,7 +40,6 @@ require (
 	github.com/yl2chen/cidranger v1.0.2 // indirect
 	github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,19 @@ module github.com/projectdiscovery/tlsx
 go 1.17
 
 require (
+	github.com/hdm/jarm-go v0.0.7
 	github.com/json-iterator/go v1.1.12
+	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/fastdialer v0.0.16-0.20220620143737-2ba20b53770a
 	github.com/projectdiscovery/fileutil v0.0.0-20220506114156-c4ab20801483
 	github.com/projectdiscovery/goflags v0.0.8
 	github.com/projectdiscovery/gologger v1.1.4
+	github.com/projectdiscovery/iputil v0.0.0-20220613112553-9b6873b2c619
 	github.com/projectdiscovery/mapcidr v1.0.0
+	github.com/rs/xid v1.4.0
 	github.com/zmap/zcrypto v0.0.0-20220605182715-4dfcec6e9a8c
+	go.uber.org/multierr v1.8.0
 )
 
 require (
@@ -20,25 +25,23 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/karrick/godirwalk v1.16.1 // indirect
-	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/miekg/dns v1.1.43 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/projectdiscovery/blackrock v0.0.0-20210415162320-b38689ae3a2e // indirect
 	github.com/projectdiscovery/cryptoutil v0.0.0-20210805184155-b5d2512f9345 // indirect
 	github.com/projectdiscovery/hmap v0.0.2-0.20210917080408-0fd7bd286bfa // indirect
-	github.com/projectdiscovery/iputil v0.0.0-20220613112553-9b6873b2c619 // indirect
 	github.com/projectdiscovery/networkpolicy v0.0.1 // indirect
 	github.com/projectdiscovery/retryabledns v1.0.13-0.20210916165024-76c5b76fd59a // indirect
 	github.com/projectdiscovery/retryablehttp-go v1.0.2 // indirect
 	github.com/projectdiscovery/stringsutil v0.0.0-20220422150559-b54fb5dc6833 // indirect
-	github.com/rs/xid v1.4.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6 // indirect
 	github.com/weppos/publicsuffix-go v0.15.1-0.20220329081811-9a40b608a236 // indirect
 	github.com/yl2chen/cidranger v1.0.2 // indirect
 	github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,10 +159,6 @@ github.com/zmap/zcrypto v0.0.0-20220605182715-4dfcec6e9a8c/go.mod h1:egdRkzUylAT
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
-go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/RumbleDiscovery/rumble-tools v0.0.0-20201105153123-f2adbb3244d2/go.mod h1:jD2+mU+E2SZUuAOHZvZj4xP4frlOo+N/YrXDvASFhkE=
 github.com/akrylysov/pogreb v0.10.0/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=
 github.com/akrylysov/pogreb v0.10.1 h1:FqlR8VR7uCbJdfUob916tPM+idpKgeESDXOA1K0DK4w=
 github.com/akrylysov/pogreb v0.10.1/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=
@@ -14,6 +15,7 @@ github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -33,6 +35,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/hdm/jarm-go v0.0.7 h1:Eq0geenHrBSYuKrdVhrBdMMzOmA+CAMLzN2WrF3eL6A=
+github.com/hdm/jarm-go v0.0.7/go.mod h1:kinGoS0+Sdn1Rr54OtanET5E5n7AlD6T6CrJAKDjJSQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -53,6 +57,7 @@ github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQ
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/miekg/dns v1.1.29/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
+github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -124,6 +129,7 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -153,9 +159,14 @@ github.com/zmap/zcrypto v0.0.0-20220605182715-4dfcec6e9a8c/go.mod h1:egdRkzUylAT
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 h1:xYJJ3S178yv++9zXV/hnr29plCAGO9vAFG9dorqaFQc=
 golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -167,6 +178,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200528225125-3c3fba18258b/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -177,6 +189,7 @@ golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR3
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -191,6 +204,7 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -23,7 +23,7 @@ var version = "v0.0.1"
 func (r *Runner) validateOptions() error {
 	r.hasStdin = fileutil.HasStdin()
 
-	probeSpecified := r.options.SO || r.options.TLSVersion || r.options.Cipher || r.options.Expired || r.options.SelfSigned || r.options.Hash != ""
+	probeSpecified := r.options.SO || r.options.TLSVersion || r.options.Cipher || r.options.Expired || r.options.SelfSigned || r.options.Hash != "" || r.options.Jarm
 	if r.options.RespOnly && probeSpecified {
 		return errors.New("resp-only flag can only be used with san and cn flags")
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -192,7 +192,7 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 	}
 	if w.options.Jarm && output.JarmHash != "" {
 		builder.WriteString(" [")
-		builder.WriteString(output.JarmHash)
+		builder.WriteString(w.aurora.Magenta(output.JarmHash).String())
 		builder.WriteString("]")
 	}
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -180,6 +180,11 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 			builder.WriteString("]")
 		}
 	}
+	if w.options.Jarm && output.JarmHash != "" {
+		builder.WriteString(" [")
+		builder.WriteString(output.JarmHash)
+		builder.WriteString("]")
+	}
 
 	outputdata := builder.Bytes()
 	return outputdata, nil

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -119,7 +119,7 @@ type Response struct {
 	TLSConnection string `json:"tls_connection,omitempty"`
 	// Chain is the chain of certificates
 	Chain    []*CertificateResponse `json:"chain,omitempty"`
-	JarmHash string                 `json:"jarmhash,omitempty"`
+	JarmHash string                 `json:"jarm_hash,omitempty"`
 }
 
 // CertificateResponse is the response for a certificate

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -84,6 +84,8 @@ type Options struct {
 	SelfSigned bool
 	// Hash is the hash to display for certificate
 	Hash string
+	// Jarm calculate jarm fingerprinting with multiple probes
+	Jarm bool
 
 	// Fastdialer is a fastdialer dialer instance
 	Fastdialer *fastdialer.Dialer
@@ -109,7 +111,8 @@ type Response struct {
 	// when ran using scan-mode auto.
 	TLSConnection string `json:"tls-connection,omitempty"`
 	// Chain is the chain of certificates
-	Chain []CertificateResponse `json:"chain,omitempty"`
+	Chain    []CertificateResponse `json:"chain,omitempty"`
+	JarmHash string                `json:"jarmhash,omitempty"`
 }
 
 // CertificateResponse is the response for a certificate

--- a/pkg/tlsx/jarm/jarm.go
+++ b/pkg/tlsx/jarm/jarm.go
@@ -1,0 +1,54 @@
+package jarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	gojarm "github.com/hdm/jarm-go"
+	"github.com/projectdiscovery/fastdialer/fastdialer"
+	"go.uber.org/multierr"
+)
+
+// fingerprint probes a single host/port
+func HashWithDialer(dialer *fastdialer.Dialer, host string, port int, timeout time.Duration) (string, error) {
+	var errs []error
+	results := []string{}
+	for _, probe := range gojarm.GetProbes(host, port) {
+		addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+		c, err := dialer.Dial(context.Background(), "tcp", addr)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if c == nil {
+			errs = append(errs, errors.New("couldn't connect"))
+			continue
+		}
+		_ = c.SetWriteDeadline(time.Now().Add(timeout))
+		_, err = c.Write(gojarm.BuildProbe(probe))
+		if err != nil {
+			results = append(results, "")
+			c.Close()
+			continue
+		}
+		_ = c.SetReadDeadline(time.Now().Add(timeout))
+		buff := make([]byte, 1484)
+		_, _ = c.Read(buff)
+		c.Close()
+		ans, err := gojarm.ParseServerHello(buff, probe)
+		if err != nil {
+			results = append(results, "")
+			continue
+		}
+		results = append(results, ans)
+	}
+	hash := gojarm.RawHashToFuzzyHash(strings.Join(results, ","))
+	if JarmHashRegex.MatchString(hash) {
+		return "", multierr.Combine(errs...)
+	}
+	return hash, nil
+}

--- a/pkg/tlsx/jarm/jarm.go
+++ b/pkg/tlsx/jarm/jarm.go
@@ -2,7 +2,6 @@ package jarm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -10,22 +9,18 @@ import (
 
 	gojarm "github.com/hdm/jarm-go"
 	"github.com/projectdiscovery/fastdialer/fastdialer"
-	"go.uber.org/multierr"
 )
 
 // fingerprint probes a single host/port
 func HashWithDialer(dialer *fastdialer.Dialer, host string, port int, timeout time.Duration) (string, error) {
-	var errs []error
 	results := []string{}
 	for _, probe := range gojarm.GetProbes(host, port) {
 		addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 		c, err := dialer.Dial(context.Background(), "tcp", addr)
 		if err != nil {
-			errs = append(errs, err)
 			continue
 		}
 		if c == nil {
-			errs = append(errs, errors.New("couldn't connect"))
 			continue
 		}
 		_ = c.SetWriteDeadline(time.Now().Add(timeout))
@@ -47,8 +42,5 @@ func HashWithDialer(dialer *fastdialer.Dialer, host string, port int, timeout ti
 		results = append(results, ans)
 	}
 	hash := gojarm.RawHashToFuzzyHash(strings.Join(results, ","))
-	if JarmHashRegex.MatchString(hash) {
-		return "", multierr.Combine(errs...)
-	}
 	return hash, nil
 }

--- a/pkg/tlsx/jarm/jarm.go
+++ b/pkg/tlsx/jarm/jarm.go
@@ -27,13 +27,13 @@ func HashWithDialer(dialer *fastdialer.Dialer, host string, port int, timeout ti
 		_, err = c.Write(gojarm.BuildProbe(probe))
 		if err != nil {
 			results = append(results, "")
-			c.Close()
+			_ = c.Close()
 			continue
 		}
 		_ = c.SetReadDeadline(time.Now().Add(timeout))
 		buff := make([]byte, 1484)
 		_, _ = c.Read(buff)
-		c.Close()
+		_ = c.Close()
 		ans, err := gojarm.ParseServerHello(buff, probe)
 		if err != nil {
 			results = append(results, "")

--- a/pkg/tlsx/jarm/regex.go
+++ b/pkg/tlsx/jarm/regex.go
@@ -1,7 +1,0 @@
-package jarm
-
-import "regexp"
-
-var (
-	JarmHashRegex = regexp.MustCompile("(?m)0{62}")
-)

--- a/pkg/tlsx/jarm/regex.go
+++ b/pkg/tlsx/jarm/regex.go
@@ -1,0 +1,7 @@
+package jarm
+
+import "regexp"
+
+var (
+	JarmHashRegex = regexp.MustCompile("(?m)0{62}")
+)

--- a/pkg/tlsx/tlsx.go
+++ b/pkg/tlsx/tlsx.go
@@ -1,9 +1,13 @@
 package tlsx
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/auto"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/jarm"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/tls"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/ztls"
 )
@@ -42,6 +46,15 @@ func (s *Service) Connect(host, port string) (*clients.Response, error) {
 	resp, err := s.client.Connect(host, port)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to host")
+	}
+	if s.options.Jarm {
+		port, _ := strconv.Atoi(port)
+		timeout := time.Duration(s.options.Timeout) * time.Second
+		jarmhash, err := jarm.HashWithDialer(s.options.Fastdialer, host, port, timeout)
+		if err != nil {
+			return resp, err
+		}
+		resp.JarmHash = jarmhash
 	}
 	return resp, nil
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=projectdiscovery_tlsx
+sonar.organization=projectdiscovery
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=tlsx
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.go.coverage.reportPaths=cov.out
+sonar.externalIssuesReportPaths=report.json
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Description
This PR implements jarm fingerprinting

## Notes
`ja3` and `ja3s` will require two independent follow-up tickets as it's necessary to access client hello and server hello raw bytes of the tls/ztls client. I suggest to grab the specific hello packets by intercepting TCP traffic with gopacket with an eBpf filter for specific TLS steps, in this way it's fully passive without any additional TLS connection required.

## Example
```console
$ echo hackerone.com:443 | go run . -jarm -silent
hackerone.com:443 [29d3dd00029d29d00042d43d00041d5de67cc9954cc85372523050f20b5007]
```