### PR TITLE
ztls ja3

### DIFF
--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -62,6 +62,7 @@ func readFlags() error {
 		flagSet.BoolVar(&options.Cipher, "cipher", false, "display used cipher"),
 		flagSet.StringVar(&options.Hash, "hash", "", "display certificate fingerprint hashes (md5,sha1,sha256)"),
 		flagSet.BoolVar(&options.Jarm, "jarm", false, "display jarm fingerprint hash"),
+		flagSet.BoolVar(&options.Ja3, "ja3", false, "display ja3 fingerprint hash (works only with ztls scan mode)"),
 		flagSet.BoolVarP(&options.ProbeStatus, "probe-status", "tps", false, "display tls probe status"),
 	)
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -151,7 +151,7 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 		builder.WriteString(w.aurora.Blue(output.ServerName).String())
 		builder.WriteString("]")
 	}
-	if w.options.SO  && len(cert.SubjectOrg) > 0 {
+	if w.options.SO && len(cert.SubjectOrg) > 0 {
 		builder.WriteString(" [")
 		builder.WriteString(w.aurora.BrightYellow(strings.Join(cert.SubjectOrg, ",")).String())
 		builder.WriteString("]")
@@ -202,6 +202,12 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 	if w.options.Jarm && output.JarmHash != "" {
 		builder.WriteString(" [")
 		builder.WriteString(w.aurora.Magenta(output.JarmHash).String())
+		builder.WriteString("]")
+	}
+
+	if w.options.Ja3 && output.Ja3Hash != "" {
+		builder.WriteString(" [")
+		builder.WriteString(w.aurora.Magenta(output.Ja3Hash).String())
 		builder.WriteString("]")
 	}
 

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -99,6 +99,8 @@ type Options struct {
 	Jarm bool
 	// Cert displays certificate in pem format
 	Cert bool
+	// Ja3 displays ja3 fingerprint hash
+	Ja3 bool
 
 	// Fastdialer is a fastdialer dialer instance
 	Fastdialer *fastdialer.Dialer
@@ -131,6 +133,7 @@ type Response struct {
 	// Chain is the chain of certificates
 	Chain      []*CertificateResponse `json:"chain,omitempty"`
 	JarmHash   string                 `json:"jarm_hash,omitempty"`
+	Ja3Hash    string                 `json:"ja3_hash,omitempty"`
 	ServerName string                 `json:"sni,omitempty"`
 }
 

--- a/pkg/tlsx/ja3/ja3.go
+++ b/pkg/tlsx/ja3/ja3.go
@@ -1,0 +1,149 @@
+package ja3
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strconv"
+
+	"github.com/zmap/zcrypto/tls"
+)
+
+const (
+	dashByte  = byte(45)
+	commaByte = byte(44)
+
+	// GREASE values
+	// The bitmask covers all GREASE values
+	greaseBitmask uint16 = 0x0F0F
+)
+
+// TLS extension numbers
+const (
+	extensionServerName           uint16 = 0
+	extensionStatusRequest        uint16 = 5
+	extensionSupportedCurves      uint16 = 10
+	extensionSupportedPoints      uint16 = 11
+	extensionSignatureAlgorithms  uint16 = 13
+	extensionALPN                 uint16 = 16
+	extensionExtendedMasterSecret uint16 = 23
+	extensionSessionTicket        uint16 = 35
+	extensionNextProtoNeg         uint16 = 13172 // not IANA assigned
+	extensionRenegotiationInfo    uint16 = 0xff01
+	extensionExtendedRandom       uint16 = 0x0028 // not IANA assigned
+	extensionSCT                  uint16 = 18
+	extensionHeartbeat            uint16 = 15
+)
+
+func GetJa3Hash(clientHello *tls.ClientHello) string {
+	byteString := make([]byte, 0)
+
+	// Version
+	byteString = strconv.AppendUint(byteString, uint64(clientHello.Version), 10)
+	byteString = append(byteString, commaByte)
+
+	// Cipher Suites
+	if len(clientHello.CipherSuites) != 0 {
+		for _, val := range clientHello.CipherSuites {
+			byteString = strconv.AppendUint(byteString, uint64(val), 10)
+			byteString = append(byteString, dashByte)
+		}
+		// Replace last dash with a comma
+		byteString[len(byteString)-1] = commaByte
+	} else {
+		byteString = append(byteString, commaByte)
+	}
+
+	// Extensions
+	if len(clientHello.ServerName) > 0 {
+		byteString = appendExtension(byteString, extensionServerName)
+	}
+
+	if clientHello.NextProtoNeg {
+		byteString = appendExtension(byteString, extensionNextProtoNeg)
+	}
+
+	if clientHello.OcspStapling {
+		byteString = appendExtension(byteString, extensionStatusRequest)
+	}
+
+	if len(clientHello.SupportedCurves) > 0 {
+		byteString = appendExtension(byteString, extensionSupportedCurves)
+	}
+
+	if len(clientHello.SupportedPoints) > 0 {
+		byteString = appendExtension(byteString, extensionSupportedPoints)
+	}
+
+	if clientHello.TicketSupported {
+		byteString = appendExtension(byteString, extensionSessionTicket)
+	}
+
+	if len(clientHello.SignatureAndHashes) > 0 {
+		byteString = appendExtension(byteString, extensionSignatureAlgorithms)
+	}
+
+	if clientHello.SecureRenegotiation {
+		byteString = appendExtension(byteString, extensionRenegotiationInfo)
+	}
+
+	if len(clientHello.AlpnProtocols) > 0 {
+		byteString = appendExtension(byteString, extensionALPN)
+	}
+
+	if clientHello.HeartbeatSupported {
+		byteString = appendExtension(byteString, extensionHeartbeat)
+	}
+
+	if len(clientHello.ExtendedRandom) > 0 {
+		byteString = appendExtension(byteString, extensionExtendedRandom)
+	}
+
+	if clientHello.ExtendedMasterSecret {
+		byteString = appendExtension(byteString, extensionExtendedMasterSecret)
+	}
+
+	if clientHello.SctEnabled {
+		byteString = appendExtension(byteString, extensionSCT)
+	}
+
+	if len(clientHello.UnknownExtensions) > 0 {
+		for _, ext := range clientHello.UnknownExtensions {
+			exType := uint16(ext[0])<<8 | uint16(ext[1])
+			byteString = appendExtension(byteString, exType)
+		}
+	}
+	// Replace last dash with a comma
+	byteString[len(byteString)-1] = commaByte
+
+	if len(clientHello.SupportedCurves) > 0 {
+		for _, val := range clientHello.SupportedCurves {
+			byteString = strconv.AppendUint(byteString, uint64(val), 10)
+			byteString = append(byteString, dashByte)
+		}
+		// Replace last dash with a comma
+		byteString[len(byteString)-1] = commaByte
+	} else {
+		byteString = append(byteString, commaByte)
+	}
+
+	if len(clientHello.SupportedPoints) > 0 {
+		for _, val := range clientHello.SupportedPoints {
+			byteString = strconv.AppendUint(byteString, uint64(val), 10)
+			byteString = append(byteString, dashByte)
+		}
+		// Remove last dash
+		byteString = byteString[:len(byteString)-1]
+	}
+
+	h := md5.Sum(byteString)
+	return hex.EncodeToString(h[:])
+}
+
+func appendExtension(byteString []byte, exType uint16) []byte {
+	// Ignore any GREASE extensions
+	if exType&greaseBitmask != 0x0A0A {
+		byteString = strconv.AppendUint(byteString, uint64(exType), 10)
+		byteString = append(byteString, dashByte)
+	}
+	return byteString
+}

--- a/pkg/tlsx/ztls/ja3/ja3.go
+++ b/pkg/tlsx/ztls/ja3/ja3.go
@@ -34,6 +34,7 @@ const (
 	extensionHeartbeat            uint16 = 15
 )
 
+// GetJa3SHash returns the JA3 fingerprint hash of the tls client hello.
 func GetJa3Hash(clientHello *tls.ClientHello) string {
 	byteString := make([]byte, 0)
 
@@ -112,9 +113,15 @@ func GetJa3Hash(clientHello *tls.ClientHello) string {
 			byteString = appendExtension(byteString, exType)
 		}
 	}
-	// Replace last dash with a comma
-	byteString[len(byteString)-1] = commaByte
+	// If dash found replace it with a comma
+	if byteString[len(byteString)-1] == dashByte {
+		byteString[len(byteString)-1] = commaByte
+	} else {
+		// else add a comma (no extension present)
+		byteString = append(byteString, commaByte)
+	}
 
+	// Suppported Elliptic Curves
 	if len(clientHello.SupportedCurves) > 0 {
 		for _, val := range clientHello.SupportedCurves {
 			byteString = strconv.AppendUint(byteString, uint64(val), 10)
@@ -126,6 +133,7 @@ func GetJa3Hash(clientHello *tls.ClientHello) string {
 		byteString = append(byteString, commaByte)
 	}
 
+	// Elliptic Curve Point Formats
 	if len(clientHello.SupportedPoints) > 0 {
 		for _, val := range clientHello.SupportedPoints {
 			byteString = strconv.AppendUint(byteString, uint64(val), 10)

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -14,7 +14,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/iputil"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
-	"github.com/projectdiscovery/tlsx/pkg/tlsx/ja3"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/ztls/ja3"
 	"github.com/rs/xid"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zcrypto/x509"

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -14,6 +14,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/iputil"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/ja3"
 	"github.com/rs/xid"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zcrypto/x509"
@@ -184,6 +185,9 @@ func (c *Client) ConnectWithOptions(hostname, port string, options clients.Conne
 		for _, cert := range hl.ServerCertificates.Chain {
 			response.Chain = append(response.Chain, c.convertCertificateToResponse(hostname, parseSimpleTLSCertificate(cert)))
 		}
+	}
+	if c.options.Ja3 {
+		response.Ja3Hash = ja3.GetJa3Hash(hl.ClientHello)
 	}
 	return response, nil
 }


### PR DESCRIPTION
Works with `ztls` scan mode only. To support for all the modes we would need to use packet capturing method leading to `libpcap` requirement.

Example:

```console
$ echo example.com | ./ztls --sm ztls --ja3       
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v0.0.4

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
example.com:443 [20c9baf81bfe95ff89722899e75d0190]
```
