### PR TITLE
Adding initial support for tls version enum

### DIFF
--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -44,7 +44,7 @@ func readFlags() error {
 	flagSet.SetDescription(`TLSX is a tls data gathering and analysis toolkit.`)
 
 	flagSet.CreateGroup("input", "Input",
-		flagSet.StringSliceVarP(&options.Inputs, "host", "u", []string{}, "target host to scan (-u INPUT1,INPUT2)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.Inputs, "host", "u", nil, "target host to scan (-u INPUT1,INPUT2)", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.StringVarP(&options.InputList, "list", "l", "", "target list to scan (-l INPUT_FILE)"),
 		flagSet.StringSliceVarP(&options.Ports, "port", "p", nil, "target port to connect (default 443)", goflags.FileCommaSeparatedStringSliceOptions),
 	)
@@ -53,7 +53,7 @@ func readFlags() error {
 		flagSet.StringVarP(&options.ScanMode, "scan-mode", "sm", "", "tls connection mode to use (ctls, ztls, auto) (default ctls)"),
 		flagSet.BoolVarP(&options.CertsOnly, "pre-handshake", "ps", false, "enable pre-handshake tls connection (early termination) using ztls"),
 		flagSet.BoolVarP(&options.ScanAllIPs, "scan-all-ips", "sa", false, "scan all ips for a host (default false)"),
-		flagSet.StringSliceVarP(&options.IPVersion, "ip-version", "iv", []string{}, "ip version to use (4, 6) (default 4)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.IPVersion, "ip-version", "iv", nil, "ip version to use (4, 6) (default 4)", goflags.NormalizedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("probes", "Probes",
@@ -67,6 +67,7 @@ func readFlags() error {
 		flagSet.BoolVar(&options.Ja3, "ja3", false, "display ja3 fingerprint hash (using ztls)"),
 		flagSet.BoolVarP(&options.WildcardCertCheck, "wildcard-cert", "wc", false, "display host with wildcard ssl certificate"),
 		flagSet.BoolVarP(&options.ProbeStatus, "probe-status", "tps", false, "display tls probe status"),
+		flagSet.BoolVarP(&options.TlsVersionsEnum, "version-enum", "ve", false, "enumerate and display supported tls versions"),
 	)
 
 	flagSet.CreateGroup("misconfigurations", "Misconfigurations",

--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -68,6 +68,7 @@ func readFlags() error {
 		flagSet.BoolVarP(&options.WildcardCertCheck, "wildcard-cert", "wc", false, "display host with wildcard ssl certificate"),
 		flagSet.BoolVarP(&options.ProbeStatus, "probe-status", "tps", false, "display tls probe status"),
 		flagSet.BoolVarP(&options.TlsVersionsEnum, "version-enum", "ve", false, "enumerate and display supported tls versions"),
+		flagSet.BoolVarP(&options.TlsCiphersEnum, "cipher-enum", "ce", false, "enumerate and display supported cipher"),
 	)
 
 	flagSet.CreateGroup("misconfigurations", "Misconfigurations",

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -221,6 +221,12 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 		builder.WriteString("]")
 	}
 
+	if w.options.TlsVersionsEnum {
+		builder.WriteString(" [")
+		builder.WriteString(w.aurora.Magenta(strings.Join(output.VersionEnum, ",")).String())
+		builder.WriteString("]")
+	}
+
 	outputdata := builder.Bytes()
 	return outputdata, nil
 }

--- a/pkg/tlsx/auto/auto.go
+++ b/pkg/tlsx/auto/auto.go
@@ -49,6 +49,11 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	return response, nil
 }
 
+// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+func (c *Client) SupportedTLSVersions() ([]string, error) {
+	return nil, errors.New("not implemented in auto mode")
+}
+
 // isResponseInvalid handles invalid response
 func (c *Client) isResponseInvalid(resp *clients.Response) bool {
 	if resp == nil {

--- a/pkg/tlsx/auto/auto.go
+++ b/pkg/tlsx/auto/auto.go
@@ -54,6 +54,11 @@ func (c *Client) SupportedTLSVersions() ([]string, error) {
 	return nil, errors.New("not implemented in auto mode")
 }
 
+// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+func (c *Client) SupportedTLSCiphers() ([]string, error) {
+	return nil, errors.New("not implemented in auto mode")
+}
+
 // isResponseInvalid handles invalid response
 func (c *Client) isResponseInvalid(resp *clients.Response) bool {
 	if resp == nil {

--- a/pkg/tlsx/auto/auto.go
+++ b/pkg/tlsx/auto/auto.go
@@ -30,7 +30,7 @@ func New(options *clients.Options) (*Client, error) {
 	}
 	opensslClient, err := openssl.New(options)
 	if err != nil && err != openssl.ErrNotSupported {
-		return nil, errors.Wrap(err, "could not create ztls client")
+		return nil, errors.Wrap(err, "could not create openssl client")
 	}
 	return &Client{tlsClient: tlsClient, ztlsClient: ztlsClient, opensslClient: opensslClient}, nil
 }
@@ -58,12 +58,12 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	return response, nil
 }
 
-// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+// SupportedTLSVersions returns the list of supported tls versions by all engines
 func (c *Client) SupportedTLSVersions() ([]string, error) {
-	return nil, errors.New("not implemented in auto mode")
+	return supportedTlsVersions, nil
 }
 
-// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+// SupportedTLSCiphers returns the list of supported ciphers by all engines
 func (c *Client) SupportedTLSCiphers() ([]string, error) {
-	return nil, errors.New("not implemented in auto mode")
+	return allCiphersNames, nil
 }

--- a/pkg/tlsx/auto/auto.go
+++ b/pkg/tlsx/auto/auto.go
@@ -3,8 +3,6 @@
 package auto
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/tlsx/pkg/output/stats"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
@@ -68,16 +66,4 @@ func (c *Client) SupportedTLSVersions() ([]string, error) {
 // SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
 func (c *Client) SupportedTLSCiphers() ([]string, error) {
 	return nil, errors.New("not implemented in auto mode")
-}
-
-// isResponseInvalid handles invalid response
-func (c *Client) isResponseInvalid(resp *clients.Response) bool {
-	if resp == nil {
-		return true
-	}
-	// case for invalid google resolving response
-	if strings.EqualFold(resp.CertificateResponse.IssuerCN, "invalid2.invalid") {
-		return true
-	}
-	return false
 }

--- a/pkg/tlsx/auto/util.go
+++ b/pkg/tlsx/auto/util.go
@@ -1,0 +1,19 @@
+package auto
+
+import (
+	"github.com/projectdiscovery/sliceutil"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/tls"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/ztls"
+)
+
+var (
+	allCiphersNames      []string
+	supportedTlsVersions []string
+)
+
+func init() {
+	allCiphersNames = append(tls.AllCiphersNames, ztls.AllCiphersNames...)
+	supportedTlsVersions = append(tls.SupportedTlsVersions, ztls.SupportedTlsVersions...)
+	allCiphersNames = sliceutil.Dedupe(allCiphersNames)
+	supportedTlsVersions = sliceutil.Dedupe(supportedTlsVersions)
+}

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -20,6 +20,8 @@ import (
 type Implementation interface {
 	// Connect connects to a host and grabs the response data
 	ConnectWithOptions(hostname, ip, port string, options ConnectOptions) (*Response, error)
+	// SupportedTLSVersions returns the list of supported tls versions
+	SupportedTLSVersions() ([]string, error)
 }
 
 // Options contains configuration options for tlsx client
@@ -107,6 +109,8 @@ type Options struct {
 	IPVersion goflags.StringSlice
 	// WildcardCertCheck enables wildcard certificate check
 	WildcardCertCheck bool
+	// TlsVersionsEnum enumerates supported tls versions
+	TlsVersionsEnum bool
 
 	// Fastdialer is a fastdialer dialer instance
 	Fastdialer *fastdialer.Dialer
@@ -137,10 +141,11 @@ type Response struct {
 	// when ran using scan-mode auto.
 	TLSConnection string `json:"tls_connection,omitempty"`
 	// Chain is the chain of certificates
-	Chain      []*CertificateResponse `json:"chain,omitempty"`
-	JarmHash   string                 `json:"jarm_hash,omitempty"`
-	Ja3Hash    string                 `json:"ja3_hash,omitempty"`
-	ServerName string                 `json:"sni,omitempty"`
+	Chain       []*CertificateResponse `json:"chain,omitempty"`
+	JarmHash    string                 `json:"jarm_hash,omitempty"`
+	Ja3Hash     string                 `json:"ja3_hash,omitempty"`
+	ServerName  string                 `json:"sni,omitempty"`
+	VersionEnum []string               `json:"version-enum,omitempty"`
 }
 
 // CertificateResponse is the response for a certificate
@@ -287,5 +292,6 @@ func PemEncode(cert []byte) string {
 }
 
 type ConnectOptions struct {
-	SNI string
+	SNI        string
+	VersionTLS string
 }

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -151,8 +151,8 @@ type Response struct {
 	JarmHash    string                 `json:"jarm_hash,omitempty"`
 	Ja3Hash     string                 `json:"ja3_hash,omitempty"`
 	ServerName  string                 `json:"sni,omitempty"`
-	VersionEnum []string               `json:"version-enum,omitempty"`
-	TlsCiphers  []TlsCiphers           `json:"cipher-enum,omitempty"`
+	VersionEnum []string               `json:"version_enum,omitempty"`
+	TlsCiphers  []TlsCiphers           `json:"cipher_enum,omitempty"`
 }
 
 type TlsCiphers struct {

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -22,6 +22,8 @@ type Implementation interface {
 	ConnectWithOptions(hostname, ip, port string, options ConnectOptions) (*Response, error)
 	// SupportedTLSVersions returns the list of supported tls versions
 	SupportedTLSVersions() ([]string, error)
+	// SupportedTLSCiphers returns the list of supported tls ciphers
+	SupportedTLSCiphers() ([]string, error)
 }
 
 // Options contains configuration options for tlsx client
@@ -111,6 +113,8 @@ type Options struct {
 	WildcardCertCheck bool
 	// TlsVersionsEnum enumerates supported tls versions
 	TlsVersionsEnum bool
+	// TlsCiphersEnum enumerates supported ciphers per TLS protocol
+	TlsCiphersEnum bool
 
 	// Fastdialer is a fastdialer dialer instance
 	Fastdialer *fastdialer.Dialer
@@ -146,6 +150,12 @@ type Response struct {
 	Ja3Hash     string                 `json:"ja3_hash,omitempty"`
 	ServerName  string                 `json:"sni,omitempty"`
 	VersionEnum []string               `json:"version-enum,omitempty"`
+	TlsCiphers  []TlsCiphers           `json:"cipher-enum,omitempty"`
+}
+
+type TlsCiphers struct {
+	Version string   `json:"version,omitempty"`
+	Ciphers []string `json:"ciphers,omitempty"`
 }
 
 // CertificateResponse is the response for a certificate
@@ -294,4 +304,5 @@ func PemEncode(cert []byte) string {
 type ConnectOptions struct {
 	SNI        string
 	VersionTLS string
+	Ciphers    []string
 }

--- a/pkg/tlsx/openssl/no_openssl.go
+++ b/pkg/tlsx/openssl/no_openssl.go
@@ -4,6 +4,7 @@
 package openssl
 
 import (
+	"github.com/pkg/errors"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
 )
 
@@ -21,4 +22,14 @@ func New(options *clients.Options) (*Client, error) {
 // Connect connects to a host and grabs the response data
 func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.ConnectOptions) (*clients.Response, error) {
 	return nil, ErrNotSupported
+}
+
+// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+func (c *Client) SupportedTLSVersions() ([]string, error) {
+	return nil, errors.New("not implemented in auto mode")
+}
+
+// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+func (c *Client) SupportedTLSCiphers() ([]string, error) {
+	return nil, errors.New("not implemented in auto mode")
 }

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -186,3 +186,13 @@ func (c *Client) convertOpenSSLToX509Certificate(opensslCert *openssl.Certificat
 
 	return x509Certificate, nil
 }
+
+// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+func (c *Client) SupportedTLSVersions() ([]string, error) {
+	return nil, errors.New("not implemented in openssl mode")
+}
+
+// SupportedTLSVersions is meaningless here but necessary due to the interface system implemented
+func (c *Client) SupportedTLSCiphers() ([]string, error) {
+	return nil, errors.New("not implemented in openssl mode")
+}

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -55,7 +55,7 @@ func New(options *clients.Options) (*Client, error) {
 	}
 
 	if options.AllCiphers {
-		c.tlsConfig.CipherSuites = allCiphers
+		c.tlsConfig.CipherSuites = AllCiphers
 	}
 	if len(options.Ciphers) > 0 {
 		if customCiphers, err := toTLSCiphers(options.Ciphers); err != nil {
@@ -221,10 +221,10 @@ func (c *Client) convertCertificateToResponse(hostname string, cert *x509.Certif
 
 // SupportedTLSVersions returns the list of standard tls library supported tls versions
 func (c *Client) SupportedTLSVersions() ([]string, error) {
-	return supportedTlsVersions, nil
+	return SupportedTlsVersions, nil
 }
 
-// SupportedTLSVersions returns the list of standard tls library supported ciphers
+// SupportedTLSCiphers returns the list of standard tls library supported ciphers
 func (c *Client) SupportedTLSCiphers() ([]string, error) {
-	return allCiphersNames, nil
+	return AllCiphersNames, nil
 }

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -7,8 +7,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -65,7 +65,7 @@ func New(options *clients.Options) (*Client, error) {
 		}
 	}
 	if options.CACertificate != "" {
-		caCert, err := ioutil.ReadFile(options.CACertificate)
+		caCert, err := os.ReadFile(options.CACertificate)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not read ca certificate")
 		}

--- a/pkg/tlsx/tls/utils.go
+++ b/pkg/tlsx/tls/utils.go
@@ -5,11 +5,19 @@ import (
 	"fmt"
 )
 
-var allCiphers []uint16
+var (
+	allCiphers           []uint16
+	allCiphersNames      []string
+	supportedTlsVersions []string
+)
 
 func init() {
-	for _, cipher := range tlsCiphers {
+	for name, cipher := range tlsCiphers {
+		allCiphersNames = append(allCiphersNames, name)
 		allCiphers = append(allCiphers, cipher)
+	}
+	for name := range versionStringToTLSVersion {
+		supportedTlsVersions = append(supportedTlsVersions, name)
 	}
 }
 

--- a/pkg/tlsx/tls/utils.go
+++ b/pkg/tlsx/tls/utils.go
@@ -6,18 +6,18 @@ import (
 )
 
 var (
-	allCiphers           []uint16
-	allCiphersNames      []string
-	supportedTlsVersions []string
+	AllCiphers           []uint16
+	AllCiphersNames      []string
+	SupportedTlsVersions []string
 )
 
 func init() {
 	for name, cipher := range tlsCiphers {
-		allCiphersNames = append(allCiphersNames, name)
-		allCiphers = append(allCiphers, cipher)
+		AllCiphersNames = append(AllCiphersNames, name)
+		AllCiphers = append(AllCiphers, cipher)
 	}
 	for name := range versionStringToTLSVersion {
-		supportedTlsVersions = append(supportedTlsVersions, name)
+		SupportedTlsVersions = append(SupportedTlsVersions, name)
 	}
 }
 

--- a/pkg/tlsx/ztls/utils.go
+++ b/pkg/tlsx/ztls/utils.go
@@ -6,11 +6,19 @@ import (
 	"github.com/zmap/zcrypto/tls"
 )
 
-var allCiphers []uint16
+var (
+	allCiphers           []uint16
+	allCiphersNames      []string
+	supportedTlsVersions []string
+)
 
 func init() {
-	for _, cipher := range ztlsCiphers {
+	for name, cipher := range ztlsCiphers {
+		allCiphersNames = append(allCiphersNames, name)
 		allCiphers = append(allCiphers, cipher)
+	}
+	for name := range versionStringToTLSVersion {
+		supportedTlsVersions = append(supportedTlsVersions, name)
 	}
 }
 

--- a/pkg/tlsx/ztls/utils.go
+++ b/pkg/tlsx/ztls/utils.go
@@ -7,18 +7,18 @@ import (
 )
 
 var (
-	allCiphers           []uint16
-	allCiphersNames      []string
-	supportedTlsVersions []string
+	AllCiphers           []uint16
+	AllCiphersNames      []string
+	SupportedTlsVersions []string
 )
 
 func init() {
 	for name, cipher := range ztlsCiphers {
-		allCiphersNames = append(allCiphersNames, name)
-		allCiphers = append(allCiphers, cipher)
+		AllCiphersNames = append(AllCiphersNames, name)
+		AllCiphers = append(AllCiphers, cipher)
 	}
 	for name := range versionStringToTLSVersion {
-		supportedTlsVersions = append(supportedTlsVersions, name)
+		SupportedTlsVersions = append(SupportedTlsVersions, name)
 	}
 }
 

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -5,8 +5,8 @@ package ztls
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -67,7 +67,7 @@ func New(options *clients.Options) (*Client, error) {
 		}
 	}
 	if options.CACertificate != "" {
-		caCert, err := ioutil.ReadFile(options.CACertificate)
+		caCert, err := os.ReadFile(options.CACertificate)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not read ca certificate")
 		}

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -57,7 +57,7 @@ func New(options *clients.Options) (*Client, error) {
 	}
 
 	if options.AllCiphers {
-		c.tlsConfig.CipherSuites = allCiphers
+		c.tlsConfig.CipherSuites = AllCiphers
 	}
 	if len(options.Ciphers) > 0 {
 		if customCiphers, err := toZTLSCiphers(options.Ciphers); err != nil {
@@ -253,12 +253,12 @@ func ConvertCertificateToResponse(options *clients.Options, hostname string, cer
 	return response
 }
 
-// SupportedTLSVersions returns the list of standard tls library supported tls versions
+// SupportedTLSVersions returns the list of ztls library supported tls versions
 func (c *Client) SupportedTLSVersions() ([]string, error) {
-	return supportedTlsVersions, nil
+	return SupportedTlsVersions, nil
 }
 
-// SupportedTLSVersions returns the list of standard tls library supported ciphers
+// SupportedTLSCiphers returns the list of ztls library supported ciphers
 func (c *Client) SupportedTLSCiphers() ([]string, error) {
-	return allCiphersNames, nil
+	return AllCiphersNames, nil
 }


### PR DESCRIPTION
## Description
This PR adds support for:
- [x] TLS version enumeration (ctls, ztls)
- [x] For each TLS version supported, enumerates ciphers up to tls 1.2 (TBD for tls1.3 ref. https://github.com/projectdiscovery/tlsx/issues/20#issuecomment-1158900782)

## Follow up investigation tickets
- https://github.com/projectdiscovery/tlsx/issues/70
- https://github.com/projectdiscovery/tlsx/issues/66

## Example
```sh
> echo hackerone.com | go run . -port 443 -ve -ce -json | jq
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  <
   |_| |____|___/_/\_\  v0.0.5

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
```
```json
{
  "timestamp": "2022-08-08T10:18:47.2387684+02:00",
  "host": "hackerone.com",
  "ip": "104.16.100.52",
  "port": "443",
  "probe_status": true,
  "tls_version": "tls13",
  "cipher": "TLS_AES_128_GCM_SHA256",
  "not_before": "2022-02-21T00:00:00Z",
  "not_after": "2023-03-24T23:59:59Z",
  "subject_dn": "CN=hackerone.com, O=HackerOne Inc., L=San Francisco, ST=California, C=US, serialNumber=5308693, businessCategory=Private Organization, jurisdictionStateOrProvince=Delaware, jurisdictionCountry=US, businessCategory=Private Organization, jurisdictionStateOrProvince=Delaware, jurisdictionCountry=US",
  "subject_cn": "hackerone.com",
  "subject_org": [
    "HackerOne Inc."
  ],
  "subject_an": [
    "hackerone.com",
    "www.hackerone.com",
    "api.hackerone.com"
  ],
  "issuer_dn": "CN=DigiCert SHA2 Extended Validation Server CA, OU=www.digicert.com, O=DigiCert Inc, C=US",
  "issuer_cn": "DigiCert SHA2 Extended Validation Server CA",
  "issuer_org": [
    "DigiCert Inc"
  ],
  "fingerprint_hash": {
    "md5": "f26c9c2b1f0a75f9419c09bd57c84e41",
    "sha1": "9118c928a478899b5d4e18e7bacc438c994e1299",
    "sha256": "61dcdf3ff2bc9ccd545fd19f6783ac8cb13c06fdaac32212e8bc1b52c2e327b0"
  },
  "tls_connection": "ctls",
  "sni": "hackerone.com",
  "version-enum": [
    "tls13",
    "tls12"
  ],
  "cipher-enum": [
    {
      "version": "tls13",
      "ciphers": [
        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
        "TLS_FALLBACK_SCSV",
        "TLS_AES_128_GCM_SHA256",
        "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
        "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
        "TLS_AES_256_GCM_SHA384",
        "TLS_RSA_WITH_AES_128_CBC_SHA",
        "TLS_RSA_WITH_AES_128_CBC_SHA256",
        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
        "TLS_RSA_WITH_AES_256_GCM_SHA384",
        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
        "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
        "TLS_RSA_WITH_AES_128_GCM_SHA256",
        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
        "TLS_CHACHA20_POLY1305_SHA256",
        "TLS_RSA_WITH_RC4_128_SHA",
        "TLS_RSA_WITH_AES_256_CBC_SHA",
        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"
      ]
    },
    {
      "version": "tls12",
      "ciphers": [
        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
        "TLS_AES_256_GCM_SHA384",
        "TLS_RSA_WITH_AES_128_CBC_SHA256",
        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
        "TLS_RSA_WITH_AES_256_GCM_SHA384",
        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"
      ]
    }
  ]
}
```