### PR TITLE
Adding support for empty sni

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,5 @@
 name: 🔨 Build Test
 on:
-  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,6 @@ name: 🚨 CodeQL Analysis
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
     branches:
       - dev

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,5 @@
 name: 🙏🏻 Lint Test
 on:
-  push:
   pull_request:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ CONFIGURATIONS:
    -cc, -cacert string          client certificate authority file
    -ci, -cipher-input string[]  ciphers to use with tls connection
    -sni string[]                tls sni hostname to use
+   -random-sni                  use random sni when empty
    -min-version string          minimum tls version to accept (ssl30,tls10,tls11,tls12,tls13)
    -max-version string          maximum tls version to accept (ssl30,tls10,tls11,tls12,tls13)
    -ac, -all-ciphers            send all ciphers as accepted inputs (default true)

--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -94,6 +94,7 @@ func readFlags() error {
 		flagSet.StringVarP(&options.CACertificate, "cacert", "cc", "", "client certificate authority file"),
 		flagSet.StringSliceVarP(&options.Ciphers, "cipher-input", "ci", nil, "ciphers to use with tls connection", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.StringSliceVar(&options.ServerName, "sni", nil, "tls sni hostname to use", goflags.FileCommaSeparatedStringSliceOptions),
+		flagSet.BoolVar(&options.RandomForEmptyServerName, "random-sni", false, "use random sni when empty"),
 		flagSet.StringVar(&options.MinVersion, "min-version", "", "minimum tls version to accept (ssl30,tls10,tls11,tls12,tls13)"),
 		flagSet.StringVar(&options.MaxVersion, "max-version", "", "maximum tls version to accept (ssl30,tls10,tls11,tls12,tls13)"),
 		flagSet.BoolVarP(&options.AllCiphers, "all-ciphers", "ac", true, "send all ciphers as accepted inputs"),

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -44,6 +44,8 @@ type Options struct {
 	InputList string
 	// ServerName is the optional server-name for tls connection
 	ServerName goflags.StringSlice
+	// RandomForEmptyServerName in case of empty sni
+	RandomForEmptyServerName bool
 	// Verbose enables display of verbose output
 	Verbose bool
 	// Version shows the version of the program

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -107,7 +107,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 	if options.SNI != "" {
 		err = conn.SetTlsExtHostName(options.SNI)
-	} else if iputil.IsIP(hostname) {
+	} else if iputil.IsIP(hostname) && c.options.RandomForEmptyServerName {
 		// using a random sni will return the default server certificate
 		err = conn.SetTlsExtHostName(xid.New().String())
 	} else {

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -126,17 +126,17 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 	config := c.tlsConfig
 	if config.ServerName == "" {
-		c := config.Clone()
+		cfg := config.Clone()
 		if options.SNI != "" {
-			c.ServerName = options.SNI
-		} else if iputil.IsIP(hostname) {
+			cfg.ServerName = options.SNI
+		} else if iputil.IsIP(hostname) && c.options.RandomForEmptyServerName {
 			// using a random sni will return the default server certificate
-			c.ServerName = xid.New().String()
+			cfg.ServerName = xid.New().String()
 		} else {
-			c.ServerName = hostname
+			cfg.ServerName = hostname
 		}
 
-		config = c
+		config = cfg
 	}
 
 	if options.VersionTLS != "" {

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -142,16 +142,16 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 	config := c.tlsConfig
 	if config.ServerName == "" {
-		c := config.Clone()
+		cfg := config.Clone()
 		if options.SNI != "" {
-			c.ServerName = options.SNI
-		} else if iputil.IsIP(hostname) {
+			cfg.ServerName = options.SNI
+		} else if iputil.IsIP(hostname) && c.options.RandomForEmptyServerName {
 			// using a random sni will return the default server certificate
-			c.ServerName = xid.New().String()
+			cfg.ServerName = xid.New().String()
 		} else {
-			c.ServerName = hostname
+			cfg.ServerName = hostname
 		}
-		config = c
+		config = cfg
 	}
 
 	if options.VersionTLS != "" {


### PR DESCRIPTION
## Description
This PR adds support for empty SNI. In case of input ip, the random sni functionality can be activated with `-random-sni`

## Example
```
$ echo 45.60.13.153:443 | go run . -json -tps
{"timestamp":"2022-11-25T15:46:57.4160234+01:00","host":"45.60.13.153","port":"443","probe_status":true,"tls_version":"tls13","cipher":"TLS_AES_128_GCM_SHA256","mismatched":true,"not_before":"2022-11-06T18:18:06Z","not_after":"2023-05-05T18:17:59Z","subject_dn":"CN=imperva.com","subject_cn":"imperva.com","subject_an":["imperva.com"],"issuer_dn":"CN=GlobalSign Atlas R3 DV TLS CA 2022 Q4, O=GlobalSign nv-sa, C=BE","issuer_cn":"GlobalSign Atlas R3 DV TLS CA 2022 Q4","issuer_org":["GlobalSign nv-sa"],"fingerprint_hash":{"md5":"e6c3115be4fd1b0c3c1688928f698dd9","sha1":"fdf030191df00db50043cdbc719cc03f80dba740","sha256":"cf29c19fc7dff5588d73bae31349ae1a40a1f92b44791bb91f5ab6623148e54e"},"tls_connection":"ctls","sni":"45.60.13.153"}
```