### PR TITLE
Fixing high memory consumption

### DIFF
--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -4,7 +4,7 @@ import (
 	"crypto/x509"
 )
 
-func Convertx509toResponse(hostname string, cert *x509.Certificate, showcert bool) *CertificateResponse {
+func Convertx509toResponse(options *Options, hostname string, cert *x509.Certificate, showcert bool) *CertificateResponse {
 	response := &CertificateResponse{
 		SubjectAN:    cert.DNSNames,
 		Emails:       cert.EmailAddresses,
@@ -13,7 +13,7 @@ func Convertx509toResponse(hostname string, cert *x509.Certificate, showcert boo
 		Expired:      IsExpired(cert.NotAfter),
 		SelfSigned:   IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId),
 		MisMatched:   IsMisMatchedCert(hostname, append(cert.DNSNames, cert.Subject.CommonName)),
-		Revoked:      IsTLSRevoked(cert),
+		Revoked:      IsTLSRevoked(options, cert),
 		WildCardCert: IsWildCardCert(append(cert.DNSNames, cert.Subject.CommonName)),
 		IssuerCN:     cert.Issuer.CommonName,
 		IssuerOrg:    cert.Issuer.Organization,

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -96,7 +96,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		ProbeStatus:         true,
 		Port:                port,
 		Version:             resp.Session.getTLSVersion(),
-		CertificateResponse: clients.Convertx509toResponse(hostname, resp.AllCerts[0], c.options.Cert),
+		CertificateResponse: clients.Convertx509toResponse(c.options, hostname, resp.AllCerts[0], c.options.Cert),
 		Cipher:              resp.Session.Cipher,
 		TLSConnection:       "openssl",
 		ServerName:          opensslOptions.ServerName,
@@ -107,7 +107,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		responses := []*clients.CertificateResponse{}
 		certs := getCertChain(ctx, opensslOptions)
 		for _, v := range certs {
-			responses = append(responses, clients.Convertx509toResponse(hostname, v, c.options.Cert))
+			responses = append(responses, clients.Convertx509toResponse(c.options, hostname, v, c.options.Cert))
 		}
 		response.Chain = responses
 	}

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -182,12 +182,12 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		Version:             tlsVersion,
 		Cipher:              tlsCipher,
 		TLSConnection:       "ctls",
-		CertificateResponse: clients.Convertx509toResponse(hostname, leafCertificate, c.options.Cert),
+		CertificateResponse: clients.Convertx509toResponse(c.options, hostname, leafCertificate, c.options.Cert),
 		ServerName:          config.ServerName,
 	}
 	if c.options.TLSChain {
 		for _, cert := range certificateChain {
-			response.Chain = append(response.Chain, clients.Convertx509toResponse(hostname, cert, c.options.Cert))
+			response.Chain = append(response.Chain, clients.Convertx509toResponse(c.options, hostname, cert, c.options.Cert))
 		}
 	}
 	return response, nil

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -248,7 +248,7 @@ func ConvertCertificateToResponse(options *clients.Options, hostname string, cer
 		Expired:      clients.IsExpired(cert.NotAfter),
 		SelfSigned:   clients.IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId),
 		MisMatched:   clients.IsMisMatchedCert(hostname, append(cert.DNSNames, cert.Subject.CommonName)),
-		Revoked:      clients.IsZTLSRevoked(cert),
+		Revoked:      clients.IsZTLSRevoked(options, cert),
 		WildCardCert: clients.IsWildCardCert(append(cert.DNSNames, cert.Subject.CommonName)),
 		IssuerDN:     cert.Issuer.String(),
 		IssuerCN:     cert.Issuer.CommonName,


### PR DESCRIPTION
## Description
This PR partially mitigates high memory consumption due to `zcrypto` internal `http.Get` calls to verify certificate revocation.

Note: confirmed to work with 3M targets