### PR TITLE
Improving openssl tls version selection

### DIFF
--- a/pkg/tlsx/openssl/common.go
+++ b/pkg/tlsx/openssl/common.go
@@ -74,9 +74,7 @@ func openSSLSetup() errorutils.Error {
 	}
 	// else assume given is openssl
 	OpenSSLVersion := arr[1]
-	/*
-		This config is only valid for openssl and not "LibreSSL"
-	*/
+	// This config is only valid for openssl and not "LibreSSL"
 	if !IsLibreSSL {
 		OPENSSL_CONF = filepath.Join(os.TempDir(), "openssl.cnf")
 		err := os.WriteFile(OPENSSL_CONF, []byte(openSSLConfig), 0600)

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -145,8 +145,13 @@ func (c *Client) getOpenSSLopts(hostname, ip, port string, options clients.Conne
 		protocolVersion = c.options.MinVersion
 	case c.options.MaxVersion != "":
 		protocolVersion = c.options.MaxVersion
+	default:
+		protocolVersion = "tls12"
 	}
-	protocol := getProtocol(protocolVersion)
+	protocol, err := getProtocol(protocolVersion)
+	if err != nil {
+		return nil, errorutils.NewWithTag("openssl", err.Error())
+	}
 
 	// Note: CLI options are omitted if given value is empty
 	opensslOptions := &Options{

--- a/pkg/tlsx/openssl/openssl_test.go
+++ b/pkg/tlsx/openssl/openssl_test.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCipherSuites(t *testing.T) {
@@ -79,9 +81,11 @@ func TestCertChain(t *testing.T) {
 func TestSessionData(t *testing.T) {
 	versions := []string{"tls10", "tls11", "tls12"}
 	for _, v := range versions {
+		prot, err := getProtocol(v)
+		require.Nil(t, err)
 		opts := &Options{
 			Address:  "scanme.sh:443",
-			Protocol: getProtocol(v),
+			Protocol: prot,
 		}
 		resp, err := getResponse(context.TODO(), opts)
 		if err != nil {

--- a/pkg/tlsx/openssl/options.go
+++ b/pkg/tlsx/openssl/options.go
@@ -2,6 +2,7 @@ package openssl
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -23,6 +24,7 @@ const (
 	TLSv1_3
 	DTLSv1
 	DTLSv1_2
+	TLSUnsupported
 )
 
 func (p *Protocols) String() string {
@@ -44,28 +46,23 @@ func (p *Protocols) String() string {
 	}
 }
 
-func getProtocol(versionTLS string) Protocols {
-	var tlsversion Protocols
+func getProtocol(versionTLS string) (Protocols, error) {
 	switch versionTLS {
 	case "tls10":
-		tlsversion = TLSv1
+		return TLSv1, nil
 	case "tls11":
-		tlsversion = TLSv1_1
+		return TLSv1_1, nil
 	case "tls12":
-		tlsversion = TLSv1_2
-		// case "tls13":
-		// 	tlsversion = TLSv1_3
-		// case "dtls10":
-		// 	tlsversion = DTLSv1
-		// case "dtls12":
-		// 	tlsversion = DTLSv1_2
+		return TLSv1_2, nil
+	// case "tls13":
+	// 	tlsversion = TLSv1_3
+	// case "dtls10":
+	// 	tlsversion = DTLSv1
+	// case "dtls12":
+	// 	tlsversion = DTLSv1_2
+	default:
+		return TLSUnsupported, errors.New("unsupported version")
 	}
-	if versionTLS == "" {
-		// if no tls version is used use tls12
-		// to avoid possible chances of handshake failures
-		return TLSv1_2
-	}
-	return tlsversion
 }
 
 // OpenSSL Command Line Options

--- a/pkg/tlsx/openssl/options.go
+++ b/pkg/tlsx/openssl/options.go
@@ -72,7 +72,7 @@ func getProtocol(versionTLS string) Protocols {
 type Options struct {
 	Address       string    // host:port address to connect
 	Cipher        []string  // Cipher to use while connecting
-	ServerName    string    //  Set TLS extension servername in ClientHello (SNI)
+	ServerName    string    // Set TLS extension servername in ClientHello (SNI)
 	CertChain     bool      // Show Certificate Chain
 	Protocol      Protocols // protocol to use
 	CAFile        string    // CA Certificate File


### PR DESCRIPTION
## Description
TLS version selection choice follow this order according to the options:
- Specific Version specified in connect options
- Min Version for the global client
- Max Version for the global client
- Empty => Default to TLS1.2