### PR TITLE
Issue 198 add untrusted ca

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ MISCONFIGURATIONS:
    -ss, -self-signed  display host with self-signed certificate
    -mm, -mismatched   display host with mismatched certificate
    -re, -revoked      display host with revoked certificate
+   -un, -untrusted    display host with untrusted certificate
 
 CONFIGURATIONS:
    -config string               path to the tlsx configuration file
@@ -322,12 +323,12 @@ support.hackerone.com:443 [TLS1.2] [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
 
 # TLS Misconfiguration
 
-### Expired / Self Signed / Mismatched / Revoked Certificate
+### Expired / Self Signed / Mismatched / Revoked / Untrusted Certificate
 
-A list of host can be provided to tlsx to detect **expired / self-signed / mismatched / revoked** certificates.
+A list of host can be provided to tlsx to detect **expired / self-signed / mismatched / revoked / untrusted** certificates.
 
 ```console
-$ tlsx -l hosts.txt -expired -self-signed -mismatched -revoked
+$ tlsx -l hosts.txt -expired -self-signed -mismatched -revoked -untrusted
   
 
   _____ _    _____  __
@@ -344,6 +345,7 @@ wrong.host.badssl.com:443 [mismatched]
 self-signed.badssl.com:443 [self-signed]
 expired.badssl.com:443 [expired]
 revoked.badssl.com:443 [revoked]
+untrusted-root.badssl.com:443 [untrusted]
 ```
 
 ### [JARM](https://engineering.salesforce.com/easily-identify-malicious-servers-on-the-internet-with-jarm-e095edac525a/) TLS Fingerprint

--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -95,6 +95,7 @@ func readFlags() error {
 		flagSet.BoolVarP(&options.SelfSigned, "self-signed", "ss", false, "display host with self-signed certificate"),
 		flagSet.BoolVarP(&options.MisMatched, "mismatched", "mm", false, "display host with mismatched certificate"),
 		flagSet.BoolVarP(&options.Revoked, "revoked", "re", false, "display host with revoked certificate"),
+		flagSet.BoolVarP(&options.Untrusted, "untrusted", "un", false, "display host with untrusted certificate"),
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -201,6 +201,11 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 		builder.WriteString(w.aurora.Red("revoked").String())
 		builder.WriteString("]")
 	}
+	if w.options.Untrusted && cert.Untrusted {
+		builder.WriteString(" [")
+		builder.WriteString(w.aurora.Yellow("untrusted").String())
+		builder.WriteString("]")
+	}
 	if w.options.WildcardCertCheck && cert.WildCardCert {
 		builder.WriteString(" [")
 		builder.WriteString(w.aurora.Yellow("wildcard").String())

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cloudflare/cfssl/revoke"
 	"github.com/logrusorgru/aurora"
 	zasn1 "github.com/zmap/zcrypto/encoding/asn1"
+	"github.com/zmap/zcrypto/tls"
 	zpkix "github.com/zmap/zcrypto/x509/pkix"
 
 	zx509 "github.com/zmap/zcrypto/x509"
@@ -402,6 +403,27 @@ func IsZTLSRevoked(options *Options, cert *zx509.Certificate) bool {
 		return options.HardFail
 	}
 	return IsTLSRevoked(options, xcert)
+}
+
+// IsUntrustedCA returns true if the certificate is a self-signed CA
+func IsUntrustedCA(certs []*x509.Certificate) bool {
+	for _, c := range certs {
+		if c.IsCA && IsSelfSigned(c.AuthorityKeyId, c.SubjectKeyId) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsZTLSUntrustedCA returns true if the certificate is a self-signed CA
+func IsZTLSUntrustedCA(certs []tls.SimpleCertificate) bool {
+	for _, cert := range certs {
+		parsedCert, _ := x509.ParseCertificate(cert.Raw)
+		if parsedCert.IsCA && IsSelfSigned(parsedCert.AuthorityKeyId, parsedCert.SubjectKeyId) {
+			return true
+		}
+	}
+	return false
 }
 
 // matchWildCardToken matches the wildcardName token and host token

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -115,6 +115,8 @@ type Options struct {
 	Expired bool
 	// SelfSigned displays if cert is self-signed
 	SelfSigned bool
+	// Untrusted displays if cert is untrusted
+	Untrusted bool
 	// MisMatched displays if the cert is mismatched
 	MisMatched bool
 	// Revoked displays if the cert is revoked
@@ -246,6 +248,8 @@ type CertificateResponse struct {
 	MisMatched bool `json:"mismatched,omitempty"`
 	// Revoked returns true if the certificate is revoked
 	Revoked bool `json:"revoked,omitempty"`
+	// Untrusted is true if the certificate is untrusted
+	Untrusted bool `json:"untrusted,omitempty"`
 	// NotBefore is the not-before time for certificate
 	NotBefore time.Time `json:"not_before,omitempty"`
 	// NotAfter is the not-after time for certificate
@@ -272,6 +276,8 @@ type CertificateResponse struct {
 	Certificate string `json:"certificate,omitempty"`
 	// WildCardCert is true if tls certificate is a wildcard certificate
 	WildCardCert bool `json:"wildcard_certificate,omitempty"`
+	// IsCA is true if the certificate is a CA certificate
+	IsCA bool `json:"is_ca,omitempty"`
 }
 
 // CertificateDistinguishedName is a distinguished certificate name

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -408,7 +408,7 @@ func IsZTLSRevoked(options *Options, cert *zx509.Certificate) bool {
 // IsUntrustedCA returns true if the certificate is a self-signed CA
 func IsUntrustedCA(certs []*x509.Certificate) bool {
 	for _, c := range certs {
-		if c.IsCA && IsSelfSigned(c.AuthorityKeyId, c.SubjectKeyId) {
+		if c != nil && c.IsCA && IsSelfSigned(c.AuthorityKeyId, c.SubjectKeyId) {
 			return true
 		}
 	}
@@ -419,7 +419,7 @@ func IsUntrustedCA(certs []*x509.Certificate) bool {
 func IsZTLSUntrustedCA(certs []tls.SimpleCertificate) bool {
 	for _, cert := range certs {
 		parsedCert, _ := x509.ParseCertificate(cert.Raw)
-		if parsedCert.IsCA && IsSelfSigned(parsedCert.AuthorityKeyId, parsedCert.SubjectKeyId) {
+		if parsedCert != nil && parsedCert.IsCA && IsSelfSigned(parsedCert.AuthorityKeyId, parsedCert.SubjectKeyId) {
 			return true
 		}
 	}

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -276,8 +276,6 @@ type CertificateResponse struct {
 	Certificate string `json:"certificate,omitempty"`
 	// WildCardCert is true if tls certificate is a wildcard certificate
 	WildCardCert bool `json:"wildcard_certificate,omitempty"`
-	// IsCA is true if the certificate is a CA certificate
-	IsCA bool `json:"is_ca,omitempty"`
 }
 
 // CertificateDistinguishedName is a distinguished certificate name

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -29,7 +29,6 @@ func Convertx509toResponse(options *Options, hostname string, cert *x509.Certifi
 			SHA1:   SHA1Fingerprint(cert.Raw),
 			SHA256: SHA256Fingerprint(cert.Raw),
 		},
-		IsCA: cert.IsCA,
 	}
 	response.IssuerDN = ParseASN1DNSequenceWithZpkixOrDefault(cert.RawIssuer, cert.Issuer.String())
 	response.SubjectDN = ParseASN1DNSequenceWithZpkixOrDefault(cert.RawSubject, cert.Subject.String())

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -29,6 +29,7 @@ func Convertx509toResponse(options *Options, hostname string, cert *x509.Certifi
 			SHA1:   SHA1Fingerprint(cert.Raw),
 			SHA256: SHA256Fingerprint(cert.Raw),
 		},
+		IsCA: cert.IsCA,
 	}
 	response.IssuerDN = ParseASN1DNSequenceWithZpkixOrDefault(cert.RawIssuer, cert.Issuer.String())
 	response.SubjectDN = ParseASN1DNSequenceWithZpkixOrDefault(cert.RawSubject, cert.Subject.String())

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -97,6 +97,15 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		}
 		response.Chain = responses
 	}
+	if c.options.Untrusted {
+		certs := getCertChain(ctx, opensslOpts)
+		for _, cert := range certs {
+			if cert.IsCA && clients.IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId) {
+				response.Untrusted = true
+				break
+			}
+		}
+	}
 	return response, nil
 }
 

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -158,6 +158,14 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 			response.Chain = append(response.Chain, clients.Convertx509toResponse(c.options, hostname, cert, c.options.Cert))
 		}
 	}
+	if c.options.Untrusted {
+		for _, cert := range certificateChain {
+			if cert.IsCA && clients.IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId) {
+				response.Untrusted = true
+				break
+			}
+		}
+	}
 	return response, nil
 }
 

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -153,17 +153,10 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		CertificateResponse: clients.Convertx509toResponse(c.options, hostname, leafCertificate, c.options.Cert),
 		ServerName:          config.ServerName,
 	}
+	response.Untrusted = clients.IsUntrustedCA(certificateChain)
 	if c.options.TLSChain {
 		for _, cert := range certificateChain {
 			response.Chain = append(response.Chain, clients.Convertx509toResponse(c.options, hostname, cert, c.options.Cert))
-		}
-	}
-	if c.options.Untrusted {
-		for _, cert := range certificateChain {
-			if cert.IsCA && clients.IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId) {
-				response.Untrusted = true
-				break
-			}
 		}
 	}
 	return response, nil

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -153,18 +153,11 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		CertificateResponse: ConvertCertificateToResponse(c.options, hostname, ParseSimpleTLSCertificate(hl.ServerCertificates.Certificate)),
 		ServerName:          config.ServerName,
 	}
+	response.Untrusted = clients.IsZTLSUntrustedCA(hl.ServerCertificates.Chain)
+
 	if c.options.TLSChain {
 		for _, cert := range hl.ServerCertificates.Chain {
 			response.Chain = append(response.Chain, ConvertCertificateToResponse(c.options, hostname, ParseSimpleTLSCertificate(cert)))
-		}
-	}
-	if c.options.Untrusted {
-		for _, cert := range hl.ServerCertificates.Chain {
-			parsedCert := ParseSimpleTLSCertificate(cert)
-			if parsedCert.IsCA && clients.IsSelfSigned(parsedCert.AuthorityKeyId, parsedCert.SubjectKeyId) {
-				response.Untrusted = true
-				break
-			}
 		}
 	}
 	if c.options.Ja3 {

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -158,6 +158,15 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 			response.Chain = append(response.Chain, ConvertCertificateToResponse(c.options, hostname, ParseSimpleTLSCertificate(cert)))
 		}
 	}
+	if c.options.Untrusted {
+		for _, cert := range hl.ServerCertificates.Chain {
+			parsedCert := ParseSimpleTLSCertificate(cert)
+			if parsedCert.IsCA && clients.IsSelfSigned(parsedCert.AuthorityKeyId, parsedCert.SubjectKeyId) {
+				response.Untrusted = true
+				break
+			}
+		}
+	}
 	if c.options.Ja3 {
 		response.Ja3Hash = ja3.GetJa3Hash(hl.ClientHello)
 	}


### PR DESCRIPTION
1. Using ztls
```
./tlsx -u untrusted-root.badssl.com  -silent -un -sm ztls
untrusted-root.badssl.com:443 [untrusted]
```

2. Using openssl
```
./tlsx -u untrusted-root.badssl.com  -silent -un -sm openssl
untrusted-root.badssl.com:443 [untrusted]
```
3. Using ctls
```
./tlsx -u untrusted-root.badssl.com  -silent -un -sm ctls
untrusted-root.badssl.com:443 [untrusted]
```
4. Using auto
```
./tlsx -u untrusted-root.badssl.com  -silent -un 
untrusted-root.badssl.com:443 [untrusted]
```

- [x] Add documentation 