### PR TITLE
add conn deadlines and fix retry logic in auto mode

### DIFF
--- a/pkg/tlsx/auto/auto.go
+++ b/pkg/tlsx/auto/auto.go
@@ -49,7 +49,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		return nil, errorutils.New("no tls client available available for auto mode")
 	}
 	var errStack error
-	for retrycounter < c.options.Retries {
+	for retrycounter < maxretires {
 		if c.tlsClient != nil {
 			if response, err = c.tlsClient.ConnectWithOptions(hostname, ip, port, options); err == nil {
 				response.TLSConnection = "ctls"

--- a/pkg/tlsx/auto/auto.go
+++ b/pkg/tlsx/auto/auto.go
@@ -39,10 +39,11 @@ func New(options *clients.Options) (*Client, error) {
 func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.ConnectOptions) (*clients.Response, error) {
 	var response *clients.Response
 	var err, ztlsErr, opensslErr error
-	retrycounter := 0
-	if c.options.Retries < 3 {
-		c.options.Retries = 3
+	maxretires := c.options.Retries
+	if maxretires < 3 {
+		maxretires = 3
 	}
+	retrycounter := 0
 	if c.tlsClient == nil && c.ztlsClient == nil && c.opensslClient == nil {
 		// logic to avoid infinite loop
 		return nil, errorutils.New("no tls client available available for auto mode")

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net"
 	"strings"
+	"time"
 
 	errorutil "github.com/projectdiscovery/utils/errors"
 	iputil "github.com/projectdiscovery/utils/ip"
@@ -87,6 +88,11 @@ func GetConn(ctx context.Context, hostname, ip, port string, inputOpts *Options)
 	if rawConn == nil {
 		return nil, errorutil.New("could not connect to %s", address)
 	}
+	if inputOpts.Timeout == 0 {
+		inputOpts.Timeout = 5
+	}
+	// will set both read and write deadline
+	rawConn.SetDeadline(time.Now().Add(time.Duration(inputOpts.Timeout) * time.Second))
 	return rawConn, nil
 }
 

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -92,8 +92,8 @@ func GetConn(ctx context.Context, hostname, ip, port string, inputOpts *Options)
 		inputOpts.Timeout = 5
 	}
 	// will set both read and write deadline
-	rawConn.SetDeadline(time.Now().Add(time.Duration(inputOpts.Timeout) * time.Second))
-	return rawConn, nil
+	err = rawConn.SetDeadline(time.Now().Add(time.Duration(inputOpts.Timeout) * time.Second))
+	return rawConn, err
 }
 
 // FormatToSerialNumber converts big.Int to colon seperated hex string

--- a/pkg/tlsx/tlsx.go
+++ b/pkg/tlsx/tlsx.go
@@ -70,10 +70,18 @@ func (s *Service) ConnectWithOptions(host, ip, port string, options clients.Conn
 		return nil, errorutil.NewWithTag("tlsx", "tlsx requires valid address got port=%v,hostname=%v,ip=%v", port, host, ip)
 	}
 
-	for i := 0; i < s.options.Retries; i++ {
+	if s.options.ScanMode != "auto" && s.options.ScanMode != "" {
+		// auto mode uses different modes as fallback
+		// hence that can be considered as retry
+		for i := 0; i < s.options.Retries; i++ {
+			if resp, err = s.client.ConnectWithOptions(host, ip, port, options); resp != nil {
+				err = nil
+				break
+			}
+		}
+	} else {
 		if resp, err = s.client.ConnectWithOptions(host, ip, port, options); resp != nil {
 			err = nil
-			break
 		}
 	}
 	if resp == nil && err == nil {


### PR DESCRIPTION
### Description

- follow up of https://github.com/projectdiscovery/tlsx/issues/263  https://github.com/projectdiscovery/nuclei/issues/3813
- adds deadline (both read and write) to every connection
- implements retry counter in auto mode
  - auto mode does fallback using all available implementations but it is not counted as retry which causes issues related to ^
  - now all fallbacks connections in auto mode are tracked as retry

### POC

- setup up open port 
```console
 $  sudo nc -dkl 440 
Password:

``` 

- run tlsx aganist this port
```console
$  cmdutil ./tlsx -u localhost -p 440 -v        
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\	v1.0.9

		projectdiscovery.io

[INF] Current tlsx version v1.0.9 (latest)
[INF] Processing input localhost:440
[WRN] Could not connect input localhost:440: [auto:RUNTIME] [ctls:RUNTIME] read tcp 127.0.0.1:55288->127.0.0.1:440: i/o timeout <- could not do handshake; [ztls:RUNTIME] failed to setup connection <- [:RUNTIME] could not connect to any address found for host <- could not dial address; [LibreSSL3.3.6,/usr/bin/openssl,LibreSSL3.3.6:RUNTIME] failed to response from openssl <- Command: /usr/bin/openssl s_client -connect localhost:440 -servername localhost -tls1_2 <- failed to execute openssl got  <- signal: killed <- could not connect to host
[INF] Connections made using crypto/tls: 0, zcrypto/tls: 0, openssl: 0

------------------------------
Command: ./tlsx -u localhost -p 440 -v
Max RSS: 32 MB
Sys Time: 38.671µs
User Time: 58.122µs
Actual Time: 10.241563s
Voluntary Context Switch (nvcsw): 42
```
> Note: by default we have retry count set to 3