### PR TITLE
support for multiple input with`-cipher-type` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 cmd/tlsx/tlsx
 dist/*
+
+.devcontainer

--- a/README.md
+++ b/README.md
@@ -76,21 +76,21 @@ SCAN-MODE:
    -iv, -ip-version string[]  ip version to use (4, 6) (default 4)
 
 PROBES:
-   -san                 display subject alternative names
-   -cn                  display subject common names
-   -so                  display subject organization name
-   -tv, -tls-version    display used tls version
-   -cipher              display used cipher
-   -hash string         display certificate fingerprint hashes (md5,sha1,sha256)
-   -jarm                display jarm fingerprint hash
-   -ja3                 display ja3 fingerprint hash (using ztls)
-   -wc, -wildcard-cert  display host with wildcard ssl certificate
-   -tps, -probe-status  display tls probe status
-   -ve, -version-enum   enumerate and display supported tls versions
-   -ce, -cipher-enum    enumerate and display supported cipher
-   -ct, -cipher-type    ciphers types to enumerate (all/secure/insecure/weak) (default 0)
-   -ch, -client-hello   include client hello in json output (ztls mode only)
-   -sh, -server-hello   include server hello in json output (ztls mode only)
+   -san                     display subject alternative names
+   -cn                      display subject common names
+   -so                      display subject organization name
+   -tv, -tls-version        display used tls version
+   -cipher                  display used cipher
+   -hash string             display certificate fingerprint hashes (md5,sha1,sha256)
+   -jarm                    display jarm fingerprint hash
+   -ja3                     display ja3 fingerprint hash (using ztls)
+   -wc, -wildcard-cert      display host with wildcard ssl certificate
+   -tps, -probe-status      display tls probe status
+   -ve, -version-enum       enumerate and display supported tls versions
+   -ce, -cipher-enum        enumerate and display supported cipher
+   -ct, -cipher-type value  ciphers types to enumerate. possible values: all/secure/insecure/weak (comma-separated) (default all)
+   -ch, -client-hello       include client hello in json output (ztls mode only)
+   -sh, -server-hello       include server hello in json output (ztls mode only)
    -se, -serial             display certificate serial number
 
 MISCONFIGURATIONS:

--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -80,7 +80,7 @@ func readFlags() error {
 		flagSet.BoolVarP(&options.ProbeStatus, "probe-status", "tps", false, "display tls probe status"),
 		flagSet.BoolVarP(&options.TlsVersionsEnum, "version-enum", "ve", false, "enumerate and display supported tls versions"),
 		flagSet.BoolVarP(&options.TlsCiphersEnum, "cipher-enum", "ce", false, "enumerate and display supported cipher"),
-		flagSet.EnumVarP(&options.TLsCipherLevel, "cipher-type", "ct", goflags.EnumVariable(0), "ciphers types to enumerate (all/secure/insecure/weak)", goflags.AllowdTypes{
+		flagSet.EnumSliceVarP(&options.TLsCipherLevel, "cipher-type", "ct", []goflags.EnumVariable{goflags.EnumVariable(0)}, "ciphers types to enumerate. possible values: all/secure/insecure/weak (comma-separated)", goflags.AllowdTypes{
 			"all":      goflags.EnumVariable(clients.All),
 			"weak":     goflags.EnumVariable(clients.Weak),
 			"insecure": goflags.EnumVariable(clients.Insecure),

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/miekg/dns v1.1.55
 	github.com/projectdiscovery/dnsx v1.1.4
 	github.com/projectdiscovery/fastdialer v0.0.35
-	github.com/projectdiscovery/goflags v0.1.12
+	github.com/projectdiscovery/goflags v0.1.13
 	github.com/projectdiscovery/gologger v1.1.11
 	github.com/projectdiscovery/mapcidr v1.1.2
 	github.com/projectdiscovery/utils v0.0.45

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdf
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
+github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
@@ -97,6 +98,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -135,6 +137,7 @@ github.com/muesli/termenv v0.15.1/go.mod h1:HeAQPTzpfs016yGtA4g00CsdYnVLJvxsS4AN
 github.com/nwaples/rardecode v1.1.3 h1:cWCaZwfM5H7nAD6PyEdcVnczzV8i/JtotnyW/dD9lEc=
 github.com/nwaples/rardecode v1.1.3/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -159,8 +162,8 @@ github.com/projectdiscovery/dnsx v1.1.4 h1:hdvIPU8W1rwNAi6sjjN1rCtCVOhS1/cM3OgmO
 github.com/projectdiscovery/dnsx v1.1.4/go.mod h1:wYz+2E97h0j25FLiqpUJyVY6NW7cEDODyUAsIoXsDsA=
 github.com/projectdiscovery/fastdialer v0.0.35 h1:dCjYaZ2dOtKmIbQ7OUuf/pZiMQRHfUjjLoHrEF8CJ8g=
 github.com/projectdiscovery/fastdialer v0.0.35/go.mod h1:dTx0C7JRWKKO5ZxGqM0NUDzB4svmyYqGM6zcHIk2ueo=
-github.com/projectdiscovery/goflags v0.1.12 h1:NucjSqw7reczmon2vQq9KyOrvOmlnznECeifHI2gOW0=
-github.com/projectdiscovery/goflags v0.1.12/go.mod h1:wC5uJonjddDcCqDNfPq+03nRessSB/LLaaIea4w47ws=
+github.com/projectdiscovery/goflags v0.1.13 h1:Kcnfw++BNjSPugEscuZ0RdRd6Iwf3cWXhNY9AB0ptHI=
+github.com/projectdiscovery/goflags v0.1.13/go.mod h1:wC5uJonjddDcCqDNfPq+03nRessSB/LLaaIea4w47ws=
 github.com/projectdiscovery/gologger v1.1.11 h1:8vsz9oJlDT9euw6xlj7F7dZ6RWItVIqVwn4Mr6uzky8=
 github.com/projectdiscovery/gologger v1.1.11/go.mod h1:UR2bgXl7zraOxYGnUwuO917hifWrwMJ0feKnVqMQkzY=
 github.com/projectdiscovery/hmap v0.0.13 h1:8v5j99Pz0S7V1YrTeWp7xtr1yNOffKQ/KusHZfB+mrI=
@@ -190,6 +193,7 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -249,6 +253,7 @@ github.com/zmap/zcrypto v0.0.0-20230422215203-9a665e1e9968/go.mod h1:xIuOvYCZX21
 github.com/zmap/zlint/v3 v3.0.0/go.mod h1:paGwFySdHIBEMJ61YjoqT4h7Ge+fdYG4sUQhnTb1lJ8=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
 go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -363,6 +368,7 @@ google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/djherbis/times.v1 v1.3.0 h1:uxMS4iMtH6Pwsxog094W0FYldiNnfY/xba00vq6C2+o=
 gopkg.in/djherbis/times.v1 v1.3.0/go.mod h1:AQlg6unIsrsCEdQYhTzERy542dz6SFdQFZFv6mUY0P8=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -371,6 +377,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -144,7 +144,7 @@ type Options struct {
 	// TlsCiphersEnum enumerates supported ciphers per TLS protocol
 	TlsCiphersEnum bool
 	// TLSCipherSecLevel
-	TLsCipherLevel string
+	TLsCipherLevel []string
 	// ClientHello include client hello (only ztls)
 	ClientHello bool
 	// ServerHello include server hello (only ztls)
@@ -471,8 +471,8 @@ type ConnectOptions struct {
 	SNI         string
 	VersionTLS  string
 	Ciphers     []string
-	CipherLevel CipherSecLevel // Only used in cipher enum mode
-	EnumMode    EnumMode       // Enumeration Mode (version or ciphers)
+	CipherLevel []CipherSecLevel // Only used in cipher enum mode
+	EnumMode    EnumMode         // Enumeration Mode (version or ciphers)
 }
 
 // ParseASN1DNSequenceWithZpkixOrDefault return the parsed value of ASN1DNSequence or a default string value

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -104,7 +104,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 // EnumerateCiphers enumerates all supported ciphers of openssl on target
 func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.ConnectOptions) ([]string, error) {
 	// filter ciphers based on given seclevel
-	toEnumerate := clients.GetCiphersWithLevel(AllCiphersNames, options.CipherLevel)
+	toEnumerate := clients.GetCiphersWithLevel(AllCiphersNames, options.CipherLevel...)
 
 	enumeratedCiphers := []string{}
 

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -164,7 +164,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.ConnectOptions) ([]string, error) {
 	// filter ciphers based on given seclevel
-	toEnumerate := clients.GetCiphersWithLevel(AllCiphersNames, options.CipherLevel)
+	toEnumerate := clients.GetCiphersWithLevel(AllCiphersNames, options.CipherLevel...)
 
 	if options.VersionTLS == "tls13" {
 		return nil, errorutil.NewWithTag("ctls", "cipher enum not supported in ctls with tls1.3")

--- a/pkg/tlsx/tlsx.go
+++ b/pkg/tlsx/tlsx.go
@@ -147,15 +147,18 @@ func (s *Service) enumTlsVersions(host, ip, port string, options clients.Connect
 
 func (s *Service) enumTlsCiphers(host, ip, port string, options clients.ConnectOptions) ([]string, error) {
 	options.EnumMode = clients.Cipher
-	switch s.options.TLsCipherLevel {
-	case "weak":
-		options.CipherLevel = clients.Weak
-	case "secure":
-		options.CipherLevel = clients.Secure
-	case "insecure":
-		options.CipherLevel = clients.Insecure
-	default:
-		options.CipherLevel = clients.All
+	for _, cipher := range s.options.TLsCipherLevel {
+
+		switch cipher {
+		case "weak":
+			options.CipherLevel = append(options.CipherLevel, clients.Weak)
+		case "secure":
+			options.CipherLevel = append(options.CipherLevel, clients.Secure)
+		case "insecure":
+			options.CipherLevel = append(options.CipherLevel, clients.Insecure)
+		default:
+			options.CipherLevel = append(options.CipherLevel, clients.All)
+		}
 	}
 	return s.client.EnumerateCiphers(host, ip, port, options)
 }

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -183,7 +183,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 // EnumerateCiphers enumerate target with ciphers supported by ztls
 func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.ConnectOptions) ([]string, error) {
 	// filter ciphers based on given seclevel
-	toEnumerate := clients.GetCiphersWithLevel(AllCiphersNames, options.CipherLevel)
+	toEnumerate := clients.GetCiphersWithLevel(AllCiphersNames, options.CipherLevel...)
 
 	enumeratedCiphers := []string{}
 


### PR DESCRIPTION
### Proposalt:
Current support:

```
echo google.com | tlsx -ce -ct insecure
``` 

Expected support:

```
echo google.com | tlsx -ce -ct insecure,weak
```

currently it's limited to using one value at a time.

Closes #306.


```console
$ go run . -u google.com -ce -ct insecure -v
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v1.1.1

                projectdiscovery.io

[INF] Current tlsx version v1.1.1 (latest)
[INF] Processing input google.com:443
[INF] Started TLS Cipher Enumeration using auto mode
[ctls] Starting cipher enumeration with 3 ciphers and version tls10
[OpenSSL1.1.1n] Starting cipher enumeration with 0 ciphers in tls10
[ztls] Starting cipher enumeration with 81 ciphers in tls10
^Csignal: interrupt

$ go run . -u google.com -ce -ct insecure,weak -v
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v1.1.1

                projectdiscovery.io

[INF] Current tlsx version v1.1.1 (latest)
[INF] Processing input google.com:443
[INF] Started TLS Cipher Enumeration using auto mode
[ctls] Starting cipher enumeration with 16 ciphers and version tls10
[OpenSSL1.1.1n] Starting cipher enumeration with 44 ciphers in tls10
[ztls] Starting cipher enumeration with 275 ciphers in tls10
^Csignal: interrupt
```