### PR TITLE
fix data race in x509->response

### DIFF
--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -14,6 +14,8 @@ import (
 )
 
 func Convertx509toResponse(options *Options, hostname string, cert *x509.Certificate, showcert bool) *CertificateResponse {
+	domainNames := []string{cert.Subject.CommonName}
+	domainNames = append(domainNames, cert.DNSNames...)
 	response := &CertificateResponse{
 		SubjectAN:    cert.DNSNames,
 		Emails:       cert.EmailAddresses,
@@ -21,9 +23,9 @@ func Convertx509toResponse(options *Options, hostname string, cert *x509.Certifi
 		NotAfter:     cert.NotAfter,
 		Expired:      IsExpired(cert.NotAfter),
 		SelfSigned:   IsSelfSigned(cert.AuthorityKeyId, cert.SubjectKeyId),
-		MisMatched:   IsMisMatchedCert(hostname, append(cert.DNSNames, cert.Subject.CommonName)),
+		MisMatched:   IsMisMatchedCert(hostname, domainNames),
 		Revoked:      IsTLSRevoked(options, cert),
-		WildCardCert: IsWildCardCert(append(cert.DNSNames, cert.Subject.CommonName)),
+		WildCardCert: IsWildCardCert(domainNames),
 		IssuerCN:     cert.Issuer.CommonName,
 		IssuerOrg:    cert.Issuer.Organization,
 		SubjectCN:    cert.Subject.CommonName,


### PR DESCRIPTION
### Proposed Changes

- when running nuclei with race detector `-race` it detected a data race in tlsx specifically due to append() function
- closes #330 

### Possible Reason

- this happens randomly (50%) even with race detector on . and issue seems to be with how `append()` function internally behaves i.e 
`append(arr , elem)` when using append new allocated slice is only returned if elem does not fit into existing array `arr` . if arr has enough space to fit elem then no new memory is allocated and `arr` itself is returned . 
our unexpected way of using `append(arr,elem)` was the cause but is now resolved since we are creating new slice and not using append for that