### PR TITLE
add dns flag

### DIFF
--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -132,6 +132,7 @@ func readFlags() error {
 	flagSet.CreateGroup("output", "Output",
 		flagSet.StringVarP(&options.OutputFile, "output", "o", "", "file to write output to"),
 		flagSet.BoolVarP(&options.JSON, "json", "j", false, "display json format output"),
+		flagSet.BoolVar(&options.DisplayDns, "dns", false, "display unique hostname from SSL certificate response"),
 		flagSet.BoolVarP(&options.RespOnly, "resp-only", "ro", false, "display tls response only"),
 		flagSet.BoolVar(&options.Silent, "silent", false, "display silent output"),
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable colors in cli output"),

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -207,7 +207,7 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 				uniqueHostnames := getUniqueHostnamesPerInput(response.CertificateResponse)
 				response.CertificateResponse.Hostname = uniqueHostnames
 				for _, hostname := range uniqueHostnames {
-					hostnamesHm.Set(hostname, nil)
+					_ = hostnamesHm.Set(hostname, nil)
 				}
 			}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -212,7 +212,9 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 			for _, hostname := range uniqueHostnames {
 				_ = hostnamesHm.Set(hostname, nil)
 			}
-			continue
+			if !r.options.JSON {
+				continue
+			}
 		}
 
 		if err := r.outputWriter.Write(response); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -202,18 +202,22 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 			gologger.Warning().Msgf("Could not connect input %s: %s", task.Address(), err)
 		}
 
-		if response != nil {
-			if r.options.DisplayDns && response.CertificateResponse != nil {
-				uniqueHostnames := getUniqueHostnamesPerInput(response.CertificateResponse)
-				response.CertificateResponse.Hostname = uniqueHostnames
-				for _, hostname := range uniqueHostnames {
-					_ = hostnamesHm.Set(hostname, nil)
-				}
-			}
+		if response == nil {
+			continue
+		}
 
-			if err := r.outputWriter.Write(response); err != nil {
-				gologger.Warning().Msgf("Could not write output %s: %s", task.Address(), err)
+		if r.options.DisplayDns && response.CertificateResponse != nil {
+			uniqueHostnames := getUniqueHostnamesPerInput(response.CertificateResponse)
+			response.CertificateResponse.Hostname = uniqueHostnames
+			for _, hostname := range uniqueHostnames {
+				_ = hostnamesHm.Set(hostname, nil)
 			}
+			continue
+		}
+
+		if err := r.outputWriter.Write(response); err != nil {
+			gologger.Warning().Msgf("Could not write output %s: %s", task.Address(), err)
+			continue
 		}
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -200,7 +200,7 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 				uniqueHostnames := getUniqueHostnamesPerInput(response.CertificateResponse)
 				response.CertificateResponse.Hostname = uniqueHostnames
 				for _, hostname := range uniqueHostnames {
-					hostnames.Set(hostname, struct{}{})
+					_ = hostnames.Set(hostname, struct{}{})
 				}
 			}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -182,11 +182,11 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 			gologger.Warning().Msgf("Could not connect input %s: %s", task.Address(), err)
 		}
 
-		if r.options.DisplayDns && response.CertificateResponse != nil {
-			response.CertificateResponse.Hostname = getUniqueHostnames(response.CertificateResponse)
-		}
-
 		if response != nil {
+			if r.options.DisplayDns && response.CertificateResponse != nil {
+				response.CertificateResponse.Hostname = getUniqueHostnames(response.CertificateResponse)
+			}
+
 			if err := r.outputWriter.Write(response); err != nil {
 				gologger.Warning().Msgf("Could not write output %s: %s", task.Address(), err)
 			}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -265,14 +265,6 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 		builder.WriteString("]")
 	}
 
-	if w.options.DisplayDns {
-		builder.WriteString("\n")
-		for _, hn := range output.Hostname {
-			builder.WriteString(hn)
-			builder.WriteString("\n")
-		}
-	}
-
 	outputdata := builder.Bytes()
 	return outputdata, nil
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -265,6 +265,14 @@ func (w *StandardWriter) formatStandard(output *clients.Response) ([]byte, error
 		builder.WriteString("]")
 	}
 
+	if w.options.DisplayDns {
+		builder.WriteString("\n")
+		for _, hn := range output.Hostname {
+			builder.WriteString(hn)
+			builder.WriteString("\n")
+		}
+	}
+
 	outputdata := builder.Bytes()
 	return outputdata, nil
 }

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -62,6 +62,8 @@ type Options struct {
 	Version bool
 	// JSON enables display of JSON output
 	JSON bool
+	// DisplayDns enables display of unique hostname from SSL certificate response
+	DisplayDns bool
 	// TLSChain enables printing TLS chain information to output
 	TLSChain bool
 	// Deprecated: AllCiphers exists for historical compatibility and should not be used
@@ -269,6 +271,8 @@ type CertificateResponse struct {
 	SubjectOrg []string `json:"subject_org,omitempty"`
 	// SubjectAN is a list of Subject Alternative Names for the certificate
 	SubjectAN []string `json:"subject_an,omitempty"`
+	// Hostname is list of  deduplicated subject_cn + subject_an
+	Hostname []string `json:"hostname,omitempty"`
 	//Serial is the certificate serial number
 	Serial string `json:"serial,omitempty"`
 	// IssuerDN is the distinguished name for cert


### PR DESCRIPTION
Closes #345.

<details>
<summary>CLI output:</summary>

```console
$ go run . -u google.com -dns
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v1.1.4

                projectdiscovery.io

[INF] Current tlsx version v1.1.4 (latest)
google.com:443
googleoptimize-cn.com
g.doubleclick.cn
safenup.googlesandbox-cn.com
youtubeeducation.com
google.pt
ampproject.org.cn
googleadapis.com
app-measurement-cn.com
ytimg.com
goo.gl
google.co.in
google.com.br
recaptcha.net.cn
googlesandbox-cn.com
gvt2.com
ggpht.cn
developers.android.google.cn
google.co.uk
google.com.ar
googlecnapps.cn
recaptcha-cn.net
googlecommerce.com
source.android.google.cn
origin-test.bdn.dev
google.com.au
google.nl
gcpcdn.gvt1.com
googletagmanager-cn.com
gvt1.com
www.goo.gl
developer.android.google.cn
ampproject.net.cn
googletraveladservices-cn.com
youtube-nocookie.com
googleapps-cn.com
doubleclick.cn
google.ca
google.it
google-analytics-cn.com
googlevads-cn.com
2mdn-cn.net
g.cn
google.com
cloud.google.com
youtubekids.com
youtu.be
youtube.com
google.es
google.pl
googlevideo.com
gkecnapps.cn
widevine.cn
admob-cn.com
crowdsource.google.com
google.com.mx
android.com
urchin.com
metric.gstatic.com
gcp.gvt2.com
g.doubleclick-cn.net
googlesyndication-cn.com
googleflights-cn.net
flash.android.com
google.fr
gstatic.cn
google.com.co
google.com.tr
gvt2-cn.com
google-analytics.com
appengine.google.com
bdn.dev
fls.doubleclick.cn
googletagservices-cn.com
safeframe.googlesyndication-cn.com
google.com.vn
doubleclick-cn.net
g.co
yt.be
datacompute.google.com
gstatic.com
gvt1-cn.com
android.clients.google.com
google.hu
fls.doubleclick-cn.net
googleadservices-cn.com
dartsearch-cn.net
url.google.com
google.cl
googleapis.cn
gstatic-cn.com
googledownloads.cn
googleapis-cn.com
google.co.jp
google.de
[INF] Connections made using crypto/tls: 1, zcrypto/tls: 0, openssl: 0
```
</details>



<details>
<summary>JSON output:</summary>

```console
$ go run . -u google.com -dns -j | jq .
  

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v1.1.4

                projectdiscovery.io

[INF] Current tlsx version v1.1.4 (latest)
[INF] Connections made using crypto/tls: 1, zcrypto/tls: 0, openssl: 0
{
  "timestamp": "2023-09-14T07:43:53.197154836Z",
  "host": "google.com",
  "ip": "172.217.18.14",
  "port": "443",
  "probe_status": true,
  "tls_version": "tls13",
  "cipher": "TLS_AES_128_GCM_SHA256",
  "not_before": "2023-08-14T08:16:28Z",
  "not_after": "2023-11-06T08:16:27Z",
  "subject_dn": "CN=*.google.com",
  "subject_cn": "*.google.com",
  "subject_an": [
    "*.google.com",
    "*.appengine.google.com",
    "*.bdn.dev",
    "*.origin-test.bdn.dev",
    "*.cloud.google.com",
    "*.crowdsource.google.com",
    "*.datacompute.google.com",
    "*.google.ca",
    "*.google.cl",
    "*.google.co.in",
    "*.google.co.jp",
    "*.google.co.uk",
    "*.google.com.ar",
    "*.google.com.au",
    "*.google.com.br",
    "*.google.com.co",
    "*.google.com.mx",
    "*.google.com.tr",
    "*.google.com.vn",
    "*.google.de",
    "*.google.es",
    "*.google.fr",
    "*.google.hu",
    "*.google.it",
    "*.google.nl",
    "*.google.pl",
    "*.google.pt",
    "*.googleadapis.com",
    "*.googleapis.cn",
    "*.googlevideo.com",
    "*.gstatic.cn",
    "*.gstatic-cn.com",
    "googlecnapps.cn",
    "*.googlecnapps.cn",
    "googleapps-cn.com",
    "*.googleapps-cn.com",
    "gkecnapps.cn",
    "*.gkecnapps.cn",
    "googledownloads.cn",
    "*.googledownloads.cn",
    "recaptcha.net.cn",
    "*.recaptcha.net.cn",
    "recaptcha-cn.net",
    "*.recaptcha-cn.net",
    "widevine.cn",
    "*.widevine.cn",
    "ampproject.org.cn",
    "*.ampproject.org.cn",
    "ampproject.net.cn",
    "*.ampproject.net.cn",
    "google-analytics-cn.com",
    "*.google-analytics-cn.com",
    "googleadservices-cn.com",
    "*.googleadservices-cn.com",
    "googlevads-cn.com",
    "*.googlevads-cn.com",
    "googleapis-cn.com",
    "*.googleapis-cn.com",
    "googleoptimize-cn.com",
    "*.googleoptimize-cn.com",
    "doubleclick-cn.net",
    "*.doubleclick-cn.net",
    "*.fls.doubleclick-cn.net",
    "*.g.doubleclick-cn.net",
    "doubleclick.cn",
    "*.doubleclick.cn",
    "*.fls.doubleclick.cn",
    "*.g.doubleclick.cn",
    "dartsearch-cn.net",
    "*.dartsearch-cn.net",
    "googletraveladservices-cn.com",
    "*.googletraveladservices-cn.com",
    "googletagservices-cn.com",
    "*.googletagservices-cn.com",
    "googletagmanager-cn.com",
    "*.googletagmanager-cn.com",
    "googlesyndication-cn.com",
    "*.googlesyndication-cn.com",
    "*.safeframe.googlesyndication-cn.com",
    "app-measurement-cn.com",
    "*.app-measurement-cn.com",
    "gvt1-cn.com",
    "*.gvt1-cn.com",
    "gvt2-cn.com",
    "*.gvt2-cn.com",
    "2mdn-cn.net",
    "*.2mdn-cn.net",
    "googleflights-cn.net",
    "*.googleflights-cn.net",
    "admob-cn.com",
    "*.admob-cn.com",
    "googlesandbox-cn.com",
    "*.googlesandbox-cn.com",
    "*.safenup.googlesandbox-cn.com",
    "*.gstatic.com",
    "*.metric.gstatic.com",
    "*.gvt1.com",
    "*.gcpcdn.gvt1.com",
    "*.gvt2.com",
    "*.gcp.gvt2.com",
    "*.url.google.com",
    "*.youtube-nocookie.com",
    "*.ytimg.com",
    "android.com",
    "*.android.com",
    "*.flash.android.com",
    "g.cn",
    "*.g.cn",
    "g.co",
    "*.g.co",
    "goo.gl",
    "www.goo.gl",
    "google-analytics.com",
    "*.google-analytics.com",
    "google.com",
    "googlecommerce.com",
    "*.googlecommerce.com",
    "ggpht.cn",
    "*.ggpht.cn",
    "urchin.com",
    "*.urchin.com",
    "youtu.be",
    "youtube.com",
    "*.youtube.com",
    "youtubeeducation.com",
    "*.youtubeeducation.com",
    "youtubekids.com",
    "*.youtubekids.com",
    "yt.be",
    "*.yt.be",
    "android.clients.google.com",
    "developer.android.google.cn",
    "developers.android.google.cn",
    "source.android.google.cn"
  ],
  "hostname": [
    "google.com",
    "google.es",
    "widevine.cn",
    "googlevads-cn.com",
    "fls.doubleclick.cn",
    "googletagmanager-cn.com",
    "googlesyndication-cn.com",
    "gcp.gvt2.com",
    "g.cn",
    "origin-test.bdn.dev",
    "fls.doubleclick-cn.net",
    "google-analytics.com",
    "bdn.dev",
    "googleadservices-cn.com",
    "g.doubleclick-cn.net",
    "doubleclick.cn",
    "2mdn-cn.net",
    "googlesandbox-cn.com",
    "gstatic.com",
    "googlecommerce.com",
    "developer.android.google.cn",
    "google.com.co",
    "google.fr",
    "google.nl",
    "googleadapis.com",
    "googleoptimize-cn.com",
    "googleflights-cn.net",
    "appengine.google.com",
    "crowdsource.google.com",
    "google.cl",
    "google.com.tr",
    "ampproject.org.cn",
    "google-analytics-cn.com",
    "googletagservices-cn.com",
    "google.co.in",
    "google.co.jp",
    "google.co.uk",
    "google.pl",
    "g.doubleclick.cn",
    "goo.gl",
    "youtubekids.com",
    "gkecnapps.cn",
    "safeframe.googlesyndication-cn.com",
    "safenup.googlesandbox-cn.com",
    "metric.gstatic.com",
    "android.com",
    "flash.android.com",
    "www.goo.gl",
    "datacompute.google.com",
    "google.de",
    "google.it",
    "googledownloads.cn",
    "gcpcdn.gvt1.com",
    "yt.be",
    "google.pt",
    "googleapis.cn",
    "ampproject.net.cn",
    "dartsearch-cn.net",
    "googletraveladservices-cn.com",
    "gvt1-cn.com",
    "ytimg.com",
    "g.co",
    "google.com.ar",
    "google.com.br",
    "gstatic-cn.com",
    "recaptcha.net.cn",
    "recaptcha-cn.net",
    "googleapis-cn.com",
    "gvt2.com",
    "url.google.com",
    "source.android.google.cn",
    "google.hu",
    "googlecnapps.cn",
    "gvt2-cn.com",
    "ggpht.cn",
    "gstatic.cn",
    "admob-cn.com",
    "gvt1.com",
    "cloud.google.com",
    "google.ca",
    "youtube-nocookie.com",
    "youtu.be",
    "android.clients.google.com",
    "googlevideo.com",
    "urchin.com",
    "developers.android.google.cn",
    "google.com.au",
    "google.com.mx",
    "google.com.vn",
    "youtube.com",
    "googleapps-cn.com",
    "doubleclick-cn.net",
    "app-measurement-cn.com",
    "youtubeeducation.com"
  ],
  "serial": "37:E9:82:7A:AE:D7:7B:A2:10:C2:A3:FB:D8:57:94:A4",
  "issuer_dn": "CN=GTS CA 1C3, O=Google Trust Services LLC, C=US",
  "issuer_cn": "GTS CA 1C3",
  "issuer_org": [
    "Google Trust Services LLC"
  ],
  "fingerprint_hash": {
    "md5": "9efe46135dafacc1d99786107afe7dba",
    "sha1": "5a485b27a7fb0bd663838e8e80db29b72c72a88e",
    "sha256": "440c58514c737c67daa272298168cdfc51b5796566f055fa55c44530bbdd0982"
  },
  "wildcard_certificate": true,
  "tls_connection": "ctls",
  "sni": "google.com"
}
```
</details>