### PR TITLE
Add support for detecting whether the server requires client authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cmd/tlsx/tlsx
 dist/*
 
 .devcontainer
+/tlsx

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
+	"github.com/projectdiscovery/utils/auth/pdcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,6 +111,14 @@ func Test_InputCIDR_processInputItem(t *testing.T) {
 }
 
 func Test_InputASN_processInputItem(t *testing.T) {
+
+	// skip if keys are missing
+	h := pdcp.PDCPCredHandler{}
+	_, err := h.GetCreds()
+	if err != nil {
+		t.Skip("skipping ASN test as keys are missing")
+	}
+
 	options := &clients.Options{
 		Ports: []string{"443"},
 	}

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -189,14 +189,15 @@ type Response struct {
 	// when ran using scan-mode auto.
 	TLSConnection string `json:"tls_connection,omitempty"`
 	// Chain is the chain of certificates
-	Chain       []*CertificateResponse `json:"chain,omitempty"`
-	JarmHash    string                 `json:"jarm_hash,omitempty"`
-	Ja3Hash     string                 `json:"ja3_hash,omitempty"`
-	ServerName  string                 `json:"sni,omitempty"`
-	VersionEnum []string               `json:"version_enum,omitempty"`
-	TlsCiphers  []TlsCiphers           `json:"cipher_enum,omitempty"`
-	ClientHello *ztls.ClientHello      `json:"client_hello,omitempty"`
-	ServerHello *ztls.ServerHello      `json:"servers_hello,omitempty"`
+	Chain              []*CertificateResponse `json:"chain,omitempty"`
+	JarmHash           string                 `json:"jarm_hash,omitempty"`
+	Ja3Hash            string                 `json:"ja3_hash,omitempty"`
+	ServerName         string                 `json:"sni,omitempty"`
+	VersionEnum        []string               `json:"version_enum,omitempty"`
+	TlsCiphers         []TlsCiphers           `json:"cipher_enum,omitempty"`
+	ClientHello        *ztls.ClientHello      `json:"client_hello,omitempty"`
+	ServerHello        *ztls.ServerHello      `json:"servers_hello,omitempty"`
+	ClientCertRequired *bool                  `json:"client_cert_required,omitempty"`
 }
 
 type TlsCiphers struct {

--- a/pkg/tlsx/openssl/common.go
+++ b/pkg/tlsx/openssl/common.go
@@ -40,7 +40,7 @@ system_default = system_default_sect
 
 [system_default_sect]
 MinProtocol = SSLv3
-CipherString = DEFAULT:@SECLEVEL=1
+CipherString = DEFAULT:@SECLEVEL=0
 `
 
 func init() {

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -86,6 +86,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		Cipher:              resp.Session.Cipher,
 		TLSConnection:       "openssl",
 		ServerName:          opensslOpts.ServerName,
+		ClientCertRequired:  &resp.ClientCertRequired,
 	}
 	certs := getCertChain(ctx, opensslOpts)
 	response.Untrusted = clients.IsUntrustedCA(certs)

--- a/pkg/tlsx/openssl/openssl_exec.go
+++ b/pkg/tlsx/openssl/openssl_exec.go
@@ -107,6 +107,7 @@ func getResponse(ctx context.Context, opts *Options) (*Response, errorutils.Erro
 		// add openssl response
 		return nil, allerrors.Msgf("failed to parse openssl response. original response is:\n%v", *result).Msgf(commadFormat, result.Command)
 	}
+	response.ClientCertRequired = isClientCertRequired(result.Stderr)
 	return response, nil
 }
 

--- a/pkg/tlsx/openssl/openssl_test.go
+++ b/pkg/tlsx/openssl/openssl_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -169,6 +170,8 @@ func TestClientCertRequired(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			log.SetOutput(io.Discard) // discard logs
+
 			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, "OK")
 			}))

--- a/pkg/tlsx/openssl/openssl_test.go
+++ b/pkg/tlsx/openssl/openssl_test.go
@@ -2,9 +2,13 @@ package openssl
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -127,6 +131,72 @@ func TestParsing(t *testing.T) {
 	// where connection is established but certificate is not sent to openssl client
 	if len(certs) > 0 && certs != nil && err == nil {
 		t.Fatalf("openssl: should fail but did not for case %v", *result)
+	}
+}
+
+func TestClientCertRequired(t *testing.T) {
+	cases := []struct {
+		name             string
+		clientAuthConfig tls.ClientAuthType
+		tlsVersion       Protocols
+		expectedResult   bool
+	}{
+		{
+			name:             "tls10_cert_required_by_server",
+			clientAuthConfig: tls.RequireAnyClientCert,
+			tlsVersion:       TLSv1,
+			expectedResult:   true,
+		},
+		{
+			name:             "tls11_cert_required_by_server",
+			clientAuthConfig: tls.RequireAnyClientCert,
+			tlsVersion:       TLSv1_1,
+			expectedResult:   true,
+		},
+		{
+			name:             "tls12_cert_required_by_server",
+			clientAuthConfig: tls.RequireAnyClientCert,
+			tlsVersion:       TLSv1_2,
+			expectedResult:   true,
+		},
+		{
+			name:             "tls12_cert_not_required_by_server",
+			clientAuthConfig: tls.NoClientCert,
+			tlsVersion:       TLSv1_2,
+			expectedResult:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, "OK")
+			}))
+
+			server.TLS.ClientAuth = tc.clientAuthConfig
+			server.TLS.MinVersion = tls.VersionTLS10
+			defer server.Close()
+
+			opts := Options{
+				Address:  strings.TrimPrefix(server.URL, "https://"),
+				Protocol: tc.tlsVersion,
+			}
+
+			args, err := opts.Args()
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			result, err := execOpenSSL(context.Background(), args)
+			if err != nil {
+				t.Errorf("failed to execute cmd:%v\ngot error %v", result.Command, err)
+			}
+
+			actualResult := isClientCertRequired(result.Stderr)
+			if actualResult != tc.expectedResult {
+				t.Errorf("expected isClientCertRequired = %t but received %t", tc.expectedResult, actualResult)
+			}
+		})
 	}
 }
 

--- a/pkg/tlsx/openssl/options.go
+++ b/pkg/tlsx/openssl/options.go
@@ -130,6 +130,7 @@ func (s *Session) getTLSVersion() string {
 
 // Openssl response
 type Response struct {
-	AllCerts []*x509.Certificate
-	Session  *Session
+	AllCerts           []*x509.Certificate
+	Session            *Session
+	ClientCertRequired bool
 }

--- a/pkg/tlsx/openssl/utils.go
+++ b/pkg/tlsx/openssl/utils.go
@@ -1,6 +1,7 @@
 package openssl
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/projectdiscovery/gologger"
@@ -42,6 +43,24 @@ func Wrap(err1 errorutil.Error, err2 errorutil.Error) errorutil.Error {
 		return err2
 	}
 	return err1.Wrap(err2)
+}
+
+var certRequiredAlerts = []string{
+	"SSL alert number 42",  // bad_certificate
+	"SSL alert number 116", // certificate_required
+}
+
+// isClientCertRequired checks openssl output to see if the error is due to a client certificate being required by the server
+func isClientCertRequired(data string) bool {
+	for _, line := range strings.Split(data, "\n") {
+		fmt.Printf("%s\n", line)
+		for _, alert := range certRequiredAlerts {
+			if strings.Contains(line, alert) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func init() {

--- a/pkg/tlsx/openssl/utils.go
+++ b/pkg/tlsx/openssl/utils.go
@@ -1,7 +1,6 @@
 package openssl
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/projectdiscovery/gologger"
@@ -53,7 +52,6 @@ var certRequiredAlerts = []string{
 // isClientCertRequired checks openssl output to see if the error is due to a client certificate being required by the server
 func isClientCertRequired(data string) bool {
 	for _, line := range strings.Split(data, "\n") {
-		fmt.Printf("%s\n", line)
 		for _, alert := range certRequiredAlerts {
 			if strings.Contains(line, alert) {
 				return true

--- a/pkg/tlsx/tls/tls_test.go
+++ b/pkg/tlsx/tls/tls_test.go
@@ -2,6 +2,8 @@ package tls_test
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -61,10 +63,11 @@ func TestClientCertRequired(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			log.SetOutput(io.Discard) // discard logs
+
 			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, "OK")
 			}))
-
 			server.TLS.ClientAuth = tc.clientAuthConfig
 			server.TLS.MinVersion = ctls.VersionTLS10
 			defer server.Close()

--- a/pkg/tlsx/tls/tls_test.go
+++ b/pkg/tlsx/tls/tls_test.go
@@ -1,0 +1,116 @@
+package tls_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	ctls "crypto/tls"
+
+	"github.com/projectdiscovery/fastdialer/fastdialer"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/tls"
+)
+
+func TestClientCertRequired(t *testing.T) {
+	cases := []struct {
+		name             string
+		clientAuthConfig ctls.ClientAuthType
+		tlsVersion       string
+		expectedResult   *bool
+	}{
+		{
+			name:             "tls10_cert_required_by_server",
+			clientAuthConfig: ctls.RequireAnyClientCert,
+			tlsVersion:       "tls10",
+			expectedResult:   boolPtr(true),
+		},
+		{
+			name:             "tls11_cert_required_by_server",
+			clientAuthConfig: ctls.RequireAnyClientCert,
+			tlsVersion:       "tls11",
+			expectedResult:   boolPtr(true),
+		},
+		{
+			name:             "tls12_cert_required_by_server",
+			clientAuthConfig: ctls.RequireAnyClientCert,
+			tlsVersion:       "tls12",
+			expectedResult:   boolPtr(true),
+		},
+		{
+			name:             "tls12_cert_not_required_by_server",
+			clientAuthConfig: ctls.NoClientCert,
+			tlsVersion:       "tls12",
+			expectedResult:   boolPtr(false),
+		},
+		{
+			name:             "tls13_cert_required_by_server",
+			clientAuthConfig: ctls.RequireAnyClientCert,
+			tlsVersion:       "tls13",
+			expectedResult:   nil,
+		},
+		{
+			name:             "tls13_cert_not_required_by_server",
+			clientAuthConfig: ctls.NoClientCert,
+			tlsVersion:       "tls13",
+			expectedResult:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, "OK")
+			}))
+
+			server.TLS.ClientAuth = tc.clientAuthConfig
+			server.TLS.MinVersion = ctls.VersionTLS10
+			defer server.Close()
+
+			parsedUrl, err := url.Parse(server.URL)
+			if err != nil {
+				t.Errorf("error parsing test server url: %s", err)
+			}
+
+			connectOpts := clients.ConnectOptions{
+				VersionTLS: tc.tlsVersion,
+			}
+
+			dialer, err := fastdialer.NewDialer(fastdialer.DefaultOptions)
+			if err != nil {
+				t.Errorf("error initializing dialer: %s", err)
+			}
+
+			clientOpts := &clients.Options{
+				Fastdialer: dialer,
+			}
+
+			client, err := tls.New(clientOpts)
+			if err != nil {
+				t.Errorf("error initializing ztls client: %s", err)
+			}
+
+			host := parsedUrl.Hostname()
+			resp, err := client.ConnectWithOptions(host, host, parsedUrl.Port(), connectOpts)
+			if err != nil {
+				t.Errorf("client ConnectWithOptions call failed: %s", err)
+			}
+
+			actualResult := resp.ClientCertRequired
+
+			if tc.expectedResult != nil && actualResult == nil {
+				t.Errorf("expected isClientCertRequired = %t but received nil", *tc.expectedResult)
+			} else if tc.expectedResult == nil && actualResult != nil {
+				t.Errorf("expected isClientCertRequired = nil but received %t", *actualResult)
+			} else if tc.expectedResult != nil && actualResult != nil && *tc.expectedResult != *actualResult {
+				t.Errorf("expected isClientCertRequired = %t but received %t", *tc.expectedResult, *actualResult)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -134,15 +134,21 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		return nil, err
 	}
 
+	var clientCertRequired bool
+
 	// new tls connection
 	tlsConn := tls.Client(conn, config)
-	if err := c.tlsHandshakeWithTimeout(tlsConn, ctx); err != nil {
-		return nil, errorutil.NewWithTag("ztls", "could not do tls handshake").Wrap(err)
+	err = c.tlsHandshakeWithTimeout(tlsConn, ctx)
+	if err != nil {
+		if clients.IsClientCertRequiredError(err) {
+			clientCertRequired = true
+		} else {
+			return nil, errorutil.NewWithTag("ztls", "could not do tls handshake").Wrap(err)
+		}
 	}
 	defer tlsConn.Close()
 
 	hl := tlsConn.GetHandshakeLog()
-
 	now := time.Now()
 	response := &clients.Response{
 		Timestamp:     &now,
@@ -162,7 +168,6 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	if hl.ServerHello != nil {
 		response.Version = versionToTLSVersionString[uint16(hl.ServerHello.Version)]
 		response.Cipher = hl.ServerHello.CipherSuite.String()
-
 	}
 
 	if c.options.TLSChain {
@@ -179,6 +184,18 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	if c.options.ServerHello {
 		response.ServerHello = hl.ServerHello
 	}
+
+	// crypto/tls allows for completing the handshake without a client certificate being provided even if one is required
+	// and doesn't return an error until the underyling connection is actually used. As a result, we will temporarily
+	// skip setting ClientCertRequired for TLS 1.3 servers since we don't yet know at this stage whether or not
+	// a client certificate is required.
+	//
+	// Note: ztls currently doesn't support TLS 1.3 but we are adding this here just to be cautious in case it is added
+	// at a future date.
+	if response.Version != "tls13" {
+		response.ClientCertRequired = &clientCertRequired
+	}
+
 	return response, nil
 }
 

--- a/pkg/tlsx/ztls/ztls_test.go
+++ b/pkg/tlsx/ztls/ztls_test.go
@@ -1,0 +1,104 @@
+package ztls_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	ctls "crypto/tls"
+
+	"github.com/projectdiscovery/fastdialer/fastdialer"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/ztls"
+)
+
+func TestClientCertRequired(t *testing.T) {
+	cases := []struct {
+		name             string
+		clientAuthConfig ctls.ClientAuthType
+		tlsVersion       string
+		expectedResult   *bool
+	}{
+		{
+			name:             "tls10_cert_required_by_server",
+			clientAuthConfig: ctls.RequireAnyClientCert,
+			tlsVersion:       "tls10",
+			expectedResult:   boolPtr(true),
+		},
+		{
+			name:             "tls11_cert_required_by_server",
+			clientAuthConfig: ctls.RequireAnyClientCert,
+			tlsVersion:       "tls11",
+			expectedResult:   boolPtr(true),
+		},
+		{
+			name:             "tls12_cert_required_by_server",
+			clientAuthConfig: ctls.RequireAnyClientCert,
+			tlsVersion:       "tls12",
+			expectedResult:   boolPtr(true),
+		},
+		{
+			name:             "tls12_cert_not_required_by_server",
+			clientAuthConfig: ctls.NoClientCert,
+			tlsVersion:       "tls12",
+			expectedResult:   boolPtr(false),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, "OK")
+			}))
+
+			server.TLS.ClientAuth = tc.clientAuthConfig
+			server.TLS.MinVersion = ctls.VersionTLS10
+			defer server.Close()
+
+			parsedUrl, err := url.Parse(server.URL)
+			if err != nil {
+				t.Errorf("error parsing test server url: %s", err)
+			}
+
+			connectOpts := clients.ConnectOptions{
+				VersionTLS: tc.tlsVersion,
+			}
+
+			dialer, err := fastdialer.NewDialer(fastdialer.DefaultOptions)
+			if err != nil {
+				t.Errorf("error initializing dialer: %s", err)
+			}
+
+			clientOpts := &clients.Options{
+				Fastdialer: dialer,
+			}
+
+			client, err := ztls.New(clientOpts)
+			if err != nil {
+				t.Errorf("error initializing ztls client: %s", err)
+			}
+
+			host := parsedUrl.Hostname()
+			resp, err := client.ConnectWithOptions(host, host, parsedUrl.Port(), connectOpts)
+			if err != nil {
+				t.Errorf("client ConnectWithOptions call failed: %s", err)
+			}
+
+			actualResult := resp.ClientCertRequired
+
+			if tc.expectedResult != nil && actualResult == nil {
+				t.Errorf("expected isClientCertRequired = %t but received nil", *tc.expectedResult)
+			} else if tc.expectedResult == nil && actualResult != nil {
+				t.Errorf("expected isClientCertRequired = nil but received %t", *actualResult)
+			} else if *tc.expectedResult != *actualResult {
+				t.Errorf("expected isClientCertRequired = %t but received %t", *tc.expectedResult, *actualResult)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/pkg/tlsx/ztls/ztls_test.go
+++ b/pkg/tlsx/ztls/ztls_test.go
@@ -2,6 +2,8 @@ package ztls_test
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -49,6 +51,8 @@ func TestClientCertRequired(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			log.SetOutput(io.Discard) // discard logs
+
 			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, "OK")
 			}))


### PR DESCRIPTION
# Summary

This change implements #564 by adding a new `client_cert_required` value to the response for the ctls, ztls, and openssl backends that returns the following values:
- `true`: if the target requires client authentication
- `false`: if the target does not require client authentication
- `null`: if we cannot determine whether or not the remote target requires client authentication

This is implemented by checking for TLS alert message 42 (`bad_certificate`) or alert message 116 (`certificate_required`).

In `openssl`, this is done by checking the stderr returned from execOpenSSL() to determine if error messages related to those specific TLS alerts are returned.

In `crypto/tls` and `ztls`, this is accomplished by parsing the underlying error returned in the `net.OpError` returned by the client when a TLS connection fails and searching for the corresponding `bad certificate` and `certificate required` messages. It should be noted that we have explicitly excluded TLS 1.3 here because `crypto/tls` consider the handshake complete and returns from `conn.HandshakeContext()` before it has dealt with the `CertificateRequest` message sent by the server. As a result, the errors are not surfaced clientside until the underlying connection is actually used. In these cases (TLS 1.3), we simply return a `nil` to indicate that we're unable to determine whether or not client authentication is required.

In addition, I noticed that TLS < 1.2 seem to no longer work with newer versions of OpenSSL. This seems to be related to [this change](https://github.com/openssl/openssl/blob/master/NEWS.md#major-changes-between-openssl-30-and-openssl-310-14-mar-2023) to move older TLS versions to security level 0 so I have updated the `openssl.cnf` to set security level = 0 as well.

# Demo
I created a local server using `crypto/tls` that had the following `tls.Config`:
```
config := &tls.Config{
    Certificates: `<auto-generated local cert>`,
    ClientAuth:   tls.RequireAnyClientCert,
    MinVersion:   tls.VersionTLS10,
}
``` 

and then ran `tlsx` like so:

```
$ tlsx -u 127.0.0.1 -p 8080 -json -max-version tls12 | jq

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v1.1.6

                projectdiscovery.io

[INF] Current tlsx version v1.1.6 (latest)
[INF] Connections made using crypto/tls: 1, zcrypto/tls: 0, openssl: 0
{
  "timestamp": "2024-06-25T11:54:30.277998-05:00",
  "host": "127.0.0.1",
  "ip": "127.0.0.1",
  "port": "8080",
  "probe_status": true,
  "tls_version": "tls13",
  "cipher": "TLS_AES_128_GCM_SHA256",
  "self_signed": true,
  "mismatched": true,
  "not_before": "2024-04-12T19:16:45Z",
  "not_after": "2025-04-12T19:16:45Z",
  "subject_dn": "emailAddress=test@test.com, CN=localhost, O=Local Dev, L=Austin, ST=Texas, C=US, emailAddress=test@test.com",
  "subject_cn": "localhost",
  "subject_org": [
    "Local Dev"
  ],
  "serial": "78:B7:DD:1A:EA:A8:C5:44:73:F2:67:ED:1F:79:16:C8:99:C8:22:92",
  "issuer_dn": "emailAddress=test@test.com, CN=localhost, O=Local Dev, L=Austin, ST=Texas, C=US, emailAddress=test@test.com",
  "issuer_cn": "localhost",
  "issuer_org": [
    "Local Dev"
  ],
  "fingerprint_hash": {
    "md5": "b1695bba154cc11b9dd4f5abac24086b",
    "sha1": "a3dcdee01cabeb998e6fd9028a4f2f086b5d2a64",
    "sha256": "4039859ba109bd3c50dda6948efa62a8ad7c47c408292f388a30432e24f27e4c"
  },
  "tls_connection": "ctls",
  "sni": "127.0.0.1",
  "client_cert_required": true
}
```

Note the new `client_cert_required` attribute at the bottom indicating that the server requires client authentication.