### PR TITLE
fix: support comma-separated values in file input (-l)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Handle comma-separated values on a single line
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +455,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Handle comma-separated values on a single line
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes

Fixes #859

The `-u` flag supports comma-separated inputs via `CommaSeparatedStringSliceOptions`, but `-l` (file input) and stdin were reading lines as-is without splitting on commas.

### Problem
```console
# This works:
./tlsx -u 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24

# But this doesn't (file contains: 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24 on one line):
./tlsx -l filename.txt
# [WRN] Could not connect input 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24:443
```

### Solution
- Split each line on commas when reading from file (`-l`)
- Also apply the same fix to stdin input for consistency
- Trim whitespace around each item
- Skip empty items after splitting

## Checklist

- [x] Pull request is created against the [main](https://github.com/projectdiscovery/tlsx/tree/main) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] `go build ./...` - compiles successfully
- [x] `go test ./...` - all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input handling now supports comma-separated values on a single line for both file and standard input, with automatic trimming and individual processing of each value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->