### PR TITLE
fix: handle comma-separated entries in -l/-list and stdin input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Handle comma-separated entries on a single line (matching -u behavior)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +455,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Handle comma-separated entries on a single line (matching -u behavior)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes #859

## Problem
The `-l`/`-list` option and stdin input treat each line as a single target without splitting on commas, unlike `-u` which correctly handles comma-separated input.

## Solution
Added comma-splitting when reading targets from input files and stdin:

```go
for _, item := range strings.Split(text, ",") {
    item = strings.TrimSpace(item)
    if item != "" {
        r.processInputItem(item, inputs)
    }
}
```

---

## Proof

### Before (upstream)
```
$ echo "scanme.nmap.org,example.com" > targets.txt
$ ./tlsx -l targets.txt

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v1.2.2

[INF] Current tlsx version v1.2.2 (latest)
# No output - fails silently because "scanme.nmap.org,example.com" is invalid
```

### After (this PR)
```
$ ./tlsx -l targets.txt

  _____ _    _____  __
 |_   _| |  / __\ \/ /
   | | | |__\__ \>  < 
   |_| |____|___/_/\_\  v1.2.2

[INF] Current tlsx version v1.2.2 (latest)
example.com:443
# Correctly splits and processes each target
```

### Test Output
```
$ go test ./...
ok   github.com/projectdiscovery/tlsx/internal/runner   0.064s
ok   github.com/projectdiscovery/tlsx/pkg/ctlogs        3.025s
ok   github.com/projectdiscovery/tlsx/pkg/output        0.027s
ok   github.com/projectdiscovery/tlsx/pkg/tlsx          6.422s
ok   github.com/projectdiscovery/tlsx/pkg/tlsx/clients  2.336s
ok   github.com/projectdiscovery/tlsx/pkg/tlsx/openssl  6.105s
ok   github.com/projectdiscovery/tlsx/pkg/tlsx/tls      0.029s
ok   github.com/projectdiscovery/tlsx/pkg/tlsx/ztls     0.026s
```

---

## Checklist
- [x] Pull request is created against the dev branch
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] Bug fix with minimal changes (1 file, +14/-2 lines)
- [x] No breaking changes