### PR TITLE
fix rootca workflow to create PR instead of direct push

### DIFF
--- a/.github/workflows/update-rootca.yml
+++ b/.github/workflows/update-rootca.yml
@@ -20,11 +20,12 @@ jobs:
       - uses: projectdiscovery/actions/setup/go@v1
       - run: go install github.com/projectdiscovery/tlsx/cmd/update-rootcerts@latest
       - run: update-rootcerts -out-root-certs ./assets/root-certs.pem
-      - uses: projectdiscovery/actions/commit@v1
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          files: 'assets/root-certs.pem'
-          message: 'chore: root CA update :robot:'
-      - name: Push changes
-        run: |
-          git pull origin $GITHUB_REF --rebase
-          git push origin $GITHUB_REF
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: root CA update'
+          title: 'chore: root CA update'
+          body: 'Automated root CA certificates update'
+          branch: chore/root-ca-update
+          delete-branch: true


### PR DESCRIPTION
Fixes #882

The workflow was failing because main branch is protected. Changed to use `peter-evans/create-pull-request` action to create a PR instead of pushing directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated multiple project dependencies to newer versions, including core modules and standard library packages, while maintaining full API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->