### PR TITLE
fix: support comma-separated values in -l flag input file

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Split by comma to support comma-separated values like -u flag
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

When reading from a file via `-l` flag, split each line by commas to match the behavior of `-u` flag which accepts comma-separated inputs.

## Proof

**Before (from issue):**
```
./tlsx -l filename.txt -v
# Where filename.txt contains: 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24
# Result: Error - treats entire line as single host
```

**After:**
```
./tlsx -l filename.txt -v
# Same file now works - each comma-separated value is processed individually
```

## Checklist

- [x] PR created against main branch
- [x] Code compiles without errors
- [x] Runner tests pass (`go test ./internal/runner/... -short`)
- [x] Change is minimal and focused

/claim #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input processing now supports comma-separated values. Each comma-separated item is parsed individually and processed separately, enabling more flexible input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->