### PR TITLE
fix: support comma-separated inputs in -l/list option

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Handle comma-separated inputs in file, consistent with -u option behavior
+				for _, item := range strings.Split(text, ",") {
+					if trimmed := strings.TrimSpace(item); trimmed != "" {
+						r.processInputItem(trimmed, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Handle comma-separated inputs from stdin, consistent with -u option behavior
+				for _, item := range strings.Split(text, ",") {
+					if trimmed := strings.TrimSpace(item); trimmed != "" {
+						r.processInputItem(trimmed, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes #859

The `-u` flag supports comma-separated inputs via `goflags.CommaSeparatedStringSliceOptions`, but the `-l/list` option only reads files line by line without handling comma-separated values on a single line.

## Changes
- Split comma-separated values when reading from input file
- Split comma-separated values when reading from stdin  
- Added tests for comma-separated domain and CIDR inputs from file

## Example
Before this fix:
```bash
# This works
./tlsx -u 192.168.1.0/24,192.168.2.0/24

# This doesn't work (file contains: 192.168.1.0/24,192.168.2.0/24)
./tlsx -l targets.txt
# Error: Could not connect input 192.168.1.0/24,192.168.2.0/24:443 [auto,ztls:RUNTIME] failed to setup connection
```

After this fix, both commands work identically - comma-separated values are properly parsed from file input.

## Testing
Added unit tests:
- `Test_InputList_CommaSeparated`: Tests comma-separated domain inputs from file
- `Test_InputList_CommaSeparatedCIDR`: Tests comma-separated CIDR inputs from file (as mentioned in the issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
- Input processing now supports comma-separated values in both file-backed input lists and standard input. Each item is automatically trimmed of whitespace and processed individually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->