### PR TITLE
fix: resolve indefinite hang in ztls handshake

### DIFF
--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -323,17 +323,18 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }

--- a/pkg/tlsx/ztls/ztls_timeout_test.go
+++ b/pkg/tlsx/ztls/ztls_timeout_test.go
@@ -3,24 +3,27 @@ package ztls
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
-	"strings"
 
 	"github.com/zmap/zcrypto/tls"
 )
 
-// hangingConn is a net.Conn that blocks on Read and Write
+// hangingConn is a net.Conn that blocks on Read and Write until context is cancelled
 type hangingConn struct {
 	net.Conn
+	ctx context.Context
 }
 
 func (h hangingConn) Read(b []byte) (n int, err error) {
-	select {}
+	<-h.ctx.Done()
+	return 0, h.ctx.Err()
 }
 
 func (h hangingConn) Write(b []byte) (n int, err error) {
-	select {}
+	<-h.ctx.Done()
+	return 0, h.ctx.Err()
 }
 
 func TestTLSHandshakeHang(t *testing.T) {
@@ -29,7 +32,15 @@ func TestTLSHandshakeHang(t *testing.T) {
 	clientConn, _ := net.Pipe()
 	defer clientConn.Close()
 
-	hanging := hangingConn{Conn: clientConn}
+	// Context to control the hanging connection's lifecycle
+	// This ensures the goroutine spawned by Handshake eventually exits
+	connCtx, connCancel := context.WithCancel(context.Background())
+	defer connCancel()
+
+	hanging := hangingConn{
+		Conn: clientConn,
+		ctx:  connCtx,
+	}
 
 	// create a tls connection using the hanging connection
 	// we don't need a real server because we want to test the client-side timeout
@@ -42,7 +53,7 @@ func TestTLSHandshakeHang(t *testing.T) {
 	// Create a dummy client just to call the method
 	client := &Client{}
 
-	// context with short timeout
+	// context with short timeout for the handshake operation
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 

--- a/pkg/tlsx/ztls/ztls_timeout_test.go
+++ b/pkg/tlsx/ztls/ztls_timeout_test.go
@@ -1,0 +1,66 @@
+package ztls
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+	"strings"
+
+	"github.com/zmap/zcrypto/tls"
+)
+
+// hangingConn is a net.Conn that blocks on Read and Write
+type hangingConn struct {
+	net.Conn
+}
+
+func (h hangingConn) Read(b []byte) (n int, err error) {
+	select {}
+}
+
+func (h hangingConn) Write(b []byte) (n int, err error) {
+	select {}
+}
+
+func TestTLSHandshakeHang(t *testing.T) {
+	// create a pipe to simulate a connection
+	// we wrap client side to ensure it hangs if it tries to read/write
+	clientConn, _ := net.Pipe()
+	defer clientConn.Close()
+
+	hanging := hangingConn{Conn: clientConn}
+
+	// create a tls connection using the hanging connection
+	// we don't need a real server because we want to test the client-side timeout
+	// when the "network" hangs during handshake hello or similar.
+	config := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	tlsConn := tls.Client(hanging, config)
+
+	// Create a dummy client just to call the method
+	client := &Client{}
+
+	// context with short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := client.tlsHandshakeWithTimeout(tlsConn, ctx)
+	duration := time.Since(start)
+
+	// Check if it respected timeout
+	if duration > 1*time.Second {
+		t.Errorf("Handshake took too long: %v, expected ~200ms", duration)
+	}
+
+	if err == nil {
+		t.Error("Expected timeout error, got nil")
+	} else {
+		// verify it's the right error
+		if !strings.Contains(err.Error(), "timeout") {
+			t.Errorf("Expected timeout error, got: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
### Description
This PR fixes the indefinite hang reported in #819.

The `tlsHandshakeWithTimeout` function in `pkg/tlsx/ztls/ztls.go` was previously blocking. I have refactored it to run in a separate goroutine with a buffered channel, ensuring the context timeout is strictly respected.

### Proof
Verified with a new test case `TestTLSHandshakeHang` that simulates a hanging connection.
<img width="1111" height="441" alt="proof41" src="https://github.com/user-attachments/assets/56fe0f96-35ab-4b1d-a466-92a779273a1b" />

Fixes #819
/claim #819


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS handshake timeout handling and error normalization so certificate-only responses are treated as successful and timeouts are reliably reported.

* **Tests**
  * Added test coverage validating TLS client handshake timeout behavior to ensure timely timeout detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->