### PR TITLE
fix(list): split comma-separated entries in -l/--list

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -38,6 +38,33 @@ func Test_InputDomain_processInputItem(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
 }
 
+func Test_InputListCommaSeparated_normalizeAndQueueInputs(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+
+	tmpDir := t.TempDir()
+	inputFile := tmpDir + string(os.PathSeparator) + "inputs.txt"
+	require.NoError(t, os.WriteFile(inputFile, []byte("example.com, example.net\n"), 0o600))
+	options.InputList = inputFile
+
+	inputs := make(chan taskInput, 4)
+	require.NoError(t, runner.normalizeAndQueueInputs(inputs))
+	close(inputs)
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+
+	expected := []taskInput{
+		{host: "example.com", port: "443"},
+		{host: "example.net", port: "443"},
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
+}
+
 func Test_InputForMultipleIps_processInputItem(t *testing.T) {
 	options := &clients.Options{
 		Ports:      []string{"443"},


### PR DESCRIPTION
/claim #859

## Problem
When using `-l/--list`, users often paste comma-separated entries (e.g. `a.com,b.com`). tlsx currently treats this as a single item instead of multiple targets.

## Fix
- Normalize list inputs by splitting comma-separated entries and trimming whitespace.
- Keeps behavior unchanged for non-comma inputs.

## Tests
Added a regression test covering comma-separated list inputs.

## Proof
```bash
GOCACHE=/tmp/gocache-tlsx go test ./internal/runner -count=1 -v
```

Test output:
```text
=== RUN   Test_InputDomain_processInputItem
--- PASS: Test_InputDomain_processInputItem (0.00s)
=== RUN   Test_InputListCommaSeparated_normalizeAndQueueInputs
--- PASS: Test_InputListCommaSeparated_normalizeAndQueueInputs (0.00s)
=== RUN   Test_InputForMultipleIps_processInputItem
--- PASS: Test_InputForMultipleIps_processInputItem (0.03s)
=== RUN   Test_InputCIDR_processInputItem
--- PASS: Test_InputCIDR_processInputItem (0.00s)
=== RUN   Test_InputASN_processInputItem
    runner_test.go:147: skipping ASN test as keys are missing
--- SKIP: Test_InputASN_processInputItem (0.00s)
=== RUN   Test_RevokedCert_processInputItem
--- PASS: Test_RevokedCert_processInputItem (0.00s)
=== RUN   Test_SelfSignedCert_processInputItem
--- PASS: Test_SelfSignedCert_processInputItem (0.00s)
=== RUN   Test_CTLogsModeValidation
    runner_test.go:242: Validation is now handled in main package
--- SKIP: Test_CTLogsModeValidation (0.00s)
=== RUN   Test_CTLogsModeDefaultEnabled
--- PASS: Test_CTLogsModeDefaultEnabled (0.00s)
=== RUN   Test_CTLogsModeWithInputDisabled
--- PASS: Test_CTLogsModeWithInputDisabled (0.00s)
=== RUN   Test_CTLogsModeWithStdinDisabled
--- PASS: Test_CTLogsModeWithStdinDisabled (0.00s)
=== RUN   Test_CTLogsModeExplicitEnabled
--- PASS: Test_CTLogsModeExplicitEnabled (0.00s)
=== RUN   Test_CTLogsModeWithSANOverride
--- PASS: Test_CTLogsModeWithSANOverride (0.00s)
=== RUN   Test_CTLogsModePortsDefault
--- PASS: Test_CTLogsModePortsDefault (0.00s)
=== RUN   Test_CTLogsModeExecute
--- PASS: Test_CTLogsModeExecute (0.00s)
=== RUN   Test_CTLogsModeWithAllProbes
=== RUN   Test_CTLogsModeWithAllProbes/SelfSigned_probe
=== RUN   Test_CTLogsModeWithAllProbes/Wildcard_probe
=== RUN   Test_CTLogsModeWithAllProbes/Expired_probe
=== RUN   Test_CTLogsModeWithAllProbes/Multiple_probes
--- PASS: Test_CTLogsModeWithAllProbes (0.00s)
    --- PASS: Test_CTLogsModeWithAllProbes/SelfSigned_probe (0.00s)
    --- PASS: Test_CTLogsModeWithAllProbes/Wildcard_probe (0.00s)
    --- PASS: Test_CTLogsModeWithAllProbes/Expired_probe (0.00s)
    --- PASS: Test_CTLogsModeWithAllProbes/Multiple_probes (0.00s)
=== RUN   Test_CTLogsModeOutputOptions
=== RUN   Test_CTLogsModeOutputOptions/JSON_output
=== RUN   Test_CTLogsModeOutputOptions/Verbose_output
=== RUN   Test_CTLogsModeOutputOptions/Silent_output
=== RUN   Test_CTLogsModeOutputOptions/Certificate_output
--- PASS: Test_CTLogsModeOutputOptions (0.00s)
    --- PASS: Test_CTLogsModeOutputOptions/JSON_output (0.00s)
    --- PASS: Test_CTLogsModeOutputOptions/Verbose_output (0.00s)
    --- PASS: Test_CTLogsModeOutputOptions/Silent_output (0.00s)
    --- PASS: Test_CTLogsModeOutputOptions/Certificate_output (0.00s)
PASS
ok  	github.com/projectdiscovery/tlsx/internal/runner	1.396s
```
