### PR TITLE
Fix -l/-list option to parse comma-separated values

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Split by comma to support comma-separated values in a single line
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +455,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Split by comma to support comma-separated values in a single line
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes #859 - The `-l/-list` option now correctly parses comma-separated values on a single line, matching the behavior of the `-u` option.

/claim #859

## Problem
The `-l/-list` option was treating entire lines as single inputs, even when they contained comma-separated values. This was inconsistent with the `-u` option which correctly splits comma-separated values.

**Before this fix:**
```bash
# This works
./tlsx -u 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24

# This fails (treats entire line as one host)
echo "192.168.1.0/24,192.168.2.0/24,192.168.3.0/24" > hosts.txt
./tlsx -l hosts.txt
# Error: Could not connect input 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24:443
```

## Solution
Modified `normalizeAndQueueInputs()` in `internal/runner/runner.go` to split each line by commas before processing. Applied the same logic to both file input and stdin for consistency.

**After this fix:**
```bash
# Both work identically now
./tlsx -u google.com,github.com,example.com
./tlsx -l hosts.txt  # where hosts.txt contains: google.com,github.com,example.com
```

## Changes
- Split file input lines by comma in `normalizeAndQueueInputs()`
- Split stdin input lines by comma for consistency
- Trim whitespace from each parsed item
- Maintains backward compatibility with newline-separated inputs

## Testing
Verified the fix works correctly:

```bash
# Test with comma-separated hosts in file
$ echo "google.com,github.com,example.com" > /tmp/test_hosts.txt
$ ./tlsx -l /tmp/test_hosts.txt -v -silent
[INF] Processing input google.com:443
[INF] Processing input github.com:443
[INF] Processing input example.com:443
google.com:443
github.com:443
example.com:443
[INF] Connections made using crypto/tls: 3, zcrypto/tls: 0, openssl: 0

# Compare with -u flag (identical behavior)
$ ./tlsx -u google.com,github.com,example.com -v -silent
[INF] Processing input github.com:443
[INF] Processing input google.com:443
[INF] Processing input example.com:443
google.com:443
github.com:443
example.com:443
[INF] Connections made using crypto/tls: 3, zcrypto/tls: 0, openssl: 0

# Test with CIDR prefixes (as mentioned in issue)
$ echo "192.168.1.1/32,192.168.1.2/32" > /tmp/test_cidrs.txt
$ ./tlsx -l /tmp/test_cidrs.txt -v -silent
[INF] Processing input 192.168.1.1:443
[INF] Processing input 192.168.1.2:443
# Both IPs processed separately (correctly)
```

All existing tests pass:
```bash
$ go test ./internal/runner
ok  	github.com/projectdiscovery/tlsx/internal/runner	0.313s
```

## Checklist
- [x] Minimal code changes (14 lines added, 2 removed)
- [x] Follows existing code style and patterns
- [x] Backward compatible with newline-separated inputs
- [x] Maintains consistency with `-u` flag behavior
- [x] All runner tests pass
- [x] Tested with various input formats (domains, IPs, CIDRs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comma-separated values in input lines are now automatically split, trimmed, and processed as individual items when reading from files or STDIN, allowing a single line to generate multiple tasks and improving batch input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->