### PR TITLE
fix: handle comma-separated entries in -l/-list and stdin input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -485,6 +485,16 @@ func (r *Runner) resolveFQDN(target string) ([]string, error) {
 
 // processInputItem processes a single input item
 func (r *Runner) processInputItem(input string, inputs chan taskInput) {
+	// Handle comma-separated entries (consistent with -u flag behavior)
+	if strings.Contains(input, ",") {
+		for _, item := range strings.Split(input, ",") {
+			item = strings.TrimSpace(item)
+			if item != "" {
+				r.processInputItem(item, inputs)
+			}
+		}
+		return
+	}
 	// AS Input
 	if asn.IsASN(input) {
 		r.processInputASN(input, inputs)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -38,6 +38,90 @@ func Test_InputDomain_processInputItem(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
 }
 
+// Comma-separated input via processInputItem
+func Test_InputCommaSeparated_processInputItem(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	commaSeparated := "example.com,example.net, example.org"
+	expected := []taskInput{
+		{host: "example.com", port: "443"},
+		{host: "example.net", port: "443"},
+		{host: "example.org", port: "443"},
+	}
+	go func() {
+		runner.processInputItem(commaSeparated, inputs)
+		defer close(inputs)
+	}()
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs for comma-separated input")
+}
+
+// Comma-separated CIDR input via processInputItem
+func Test_InputCommaSeparatedCIDR_processInputItem(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	commaSeparated := "173.0.84.0/30,173.0.85.0/30"
+	expected := []taskInput{
+		{host: "173.0.84.0", port: "443"},
+		{host: "173.0.84.1", port: "443"},
+		{host: "173.0.84.2", port: "443"},
+		{host: "173.0.84.3", port: "443"},
+		{host: "173.0.85.0", port: "443"},
+		{host: "173.0.85.1", port: "443"},
+		{host: "173.0.85.2", port: "443"},
+		{host: "173.0.85.3", port: "443"},
+	}
+	go func() {
+		runner.processInputItem(commaSeparated, inputs)
+		defer close(inputs)
+	}()
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs for comma-separated CIDR input")
+}
+
+// Comma-separated input from file via normalizeAndQueueInputs
+func Test_InputListCommaSeparated_normalizeAndQueueInputs(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+
+	tmpDir := t.TempDir()
+	inputFile := tmpDir + string(os.PathSeparator) + "inputs.txt"
+	require.NoError(t, os.WriteFile(inputFile, []byte("example.com, example.net\nexample.org\n"), 0o600))
+	options.InputList = inputFile
+
+	inputs := make(chan taskInput, 8)
+	require.NoError(t, runner.normalizeAndQueueInputs(inputs))
+	close(inputs)
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+
+	expected := []taskInput{
+		{host: "example.com", port: "443"},
+		{host: "example.net", port: "443"},
+		{host: "example.org", port: "443"},
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs for comma-separated file input")
+}
+
 func Test_InputForMultipleIps_processInputItem(t *testing.T) {
 	options := &clients.Options{
 		Ports:      []string{"443"},


### PR DESCRIPTION
## Proposed Changes

Fixes #859

### Problem

The `-l`/`-list` file input and stdin treat each line as a single target, not splitting on commas like the `-u` option does. This causes comma-separated entries (e.g. `192.168.1.0/24,192.168.2.0/24`) to fail with `no address found for host` errors because the entire comma-separated string is treated as a single hostname.

### Solution

Add comma-splitting logic in `processInputItem` so it applies uniformly to all input sources in a single place. When input contains a comma, it is split, trimmed, and each non-empty item is processed individually via recursive call.

This approach differs from previous attempts that duplicated the split logic at each call site (file reader and stdin reader). By handling it in `processInputItem`, the fix is DRY and automatically covers any future input sources.

### Changes

- Modified `processInputItem` in `internal/runner/runner.go` to detect and split comma-separated entries
- Added 3 tests:
  - `Test_InputCommaSeparated_processInputItem` — comma-separated domains
  - `Test_InputCommaSeparatedCIDR_processInputItem` — comma-separated CIDRs
  - `Test_InputListCommaSeparated_normalizeAndQueueInputs` — comma-separated entries from file input

### Proof

Before (single line fails):
```
echo "192.168.1.1,192.168.2.1" > /tmp/test.txt
./tlsx -l /tmp/test.txt -p 443
# [WRN] Could not connect input 192.168.1.1,192.168.2.1:443
```

After (both hosts processed separately):
```
echo "192.168.1.1,192.168.2.1" > /tmp/test.txt
./tlsx -l /tmp/test.txt -p 443
# Scans 192.168.1.1:443 and 192.168.2.1:443 separately
```

## Checklist

- [x] PR created against the correct branch (dev)
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] No dependency changes (go.mod/go.sum untouched)