### PR TITLE
fix: prevent indefinite hang in TLS handshake and cipher enumeration

### DIFF
--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -236,10 +236,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 
 		conn := tls.Client(baseConn, baseCfg)
 
-		if err := conn.Handshake(); err == nil {
+		cipherCtx, cipherCancel := c.cipherHandshakeContext()
+		if err := conn.HandshakeContext(cipherCtx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
+		cipherCancel()
 		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil
@@ -253,6 +255,15 @@ func (c *Client) SupportedTLSVersions() ([]string, error) {
 // SupportedTLSCiphers returns the list of standard tls library supported ciphers
 func (c *Client) SupportedTLSCiphers() ([]string, error) {
 	return AllCiphersNames, nil
+}
+
+// cipherHandshakeContext returns a context with timeout for per-cipher handshakes.
+func (c *Client) cipherHandshakeContext() (context.Context, context.CancelFunc) {
+	timeout := time.Duration(c.options.Timeout) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return context.WithTimeout(context.Background(), timeout)
 }
 
 // getConfig returns a valid config to be used by client

--- a/pkg/tlsx/tls/tls_timeout_test.go
+++ b/pkg/tlsx/tls/tls_timeout_test.go
@@ -1,0 +1,46 @@
+package tls
+
+import (
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
+)
+
+func TestCipherHandshakeContext_UsesConfiguredTimeout(t *testing.T) {
+	client := &Client{
+		options: &clients.Options{Timeout: 3},
+	}
+
+	ctx, cancel := client.cipherHandshakeContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected context with deadline")
+	}
+
+	remaining := time.Until(deadline)
+	if remaining < 2*time.Second || remaining > 4*time.Second {
+		t.Fatalf("expected ~3s deadline, got %v remaining", remaining)
+	}
+}
+
+func TestCipherHandshakeContext_DefaultsWhenZero(t *testing.T) {
+	client := &Client{
+		options: &clients.Options{Timeout: 0},
+	}
+
+	ctx, cancel := client.cipherHandshakeContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected context with deadline")
+	}
+
+	remaining := time.Until(deadline)
+	if remaining < 9*time.Second || remaining > 11*time.Second {
+		t.Fatalf("expected ~10s default deadline, got %v remaining", remaining)
+	}
+}

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -140,7 +140,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 	// new tls connection
 	tlsConn := tls.Client(conn, config)
-	err = c.tlsHandshakeWithTimeout(tlsConn, ctx)
+	err = c.tlsHandshakeWithTimeout(tlsConn, conn, ctx)
 	if err != nil {
 		if clients.IsClientCertRequiredError(err) {
 			clientCertRequired = true
@@ -257,10 +257,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		cipherCtx, cipherCancel := c.cipherHandshakeContext()
+		if err := c.tlsHandshakeWithTimeout(conn, baseConn, cipherCtx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
+		cipherCancel()
 		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil
@@ -320,20 +322,38 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 	return config, nil
 }
 
-// tlsHandshakeWithCtx attempts tls handshake with given timeout
-func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
+// cipherHandshakeContext returns a context with timeout for per-cipher handshakes.
+func (c *Client) cipherHandshakeContext() (context.Context, context.CancelFunc) {
+	timeout := time.Duration(c.options.Timeout) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+// tlsHandshakeWithTimeout attempts tls handshake with given timeout.
+// The handshake runs in a separate goroutine so the context cancellation
+// can interrupt a blocking handshake (e.g. unresponsive server).
+// rawConn is the underlying TCP connection; closing it unblocks the handshake
+// goroutine without deadlocking on the zcrypto TLS mutex.
+func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, rawConn net.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
+		// Close the underlying TCP connection to unblock the handshake
+		// goroutine. Closing the TLS conn directly would deadlock because
+		// the handshake holds the internal mutex.
+		_ = rawConn.Close()
+		<-errChan // wait for goroutine to exit
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }

--- a/pkg/tlsx/ztls/ztls_timeout_test.go
+++ b/pkg/tlsx/ztls/ztls_timeout_test.go
@@ -1,0 +1,98 @@
+package ztls
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
+	"github.com/zmap/zcrypto/tls"
+)
+
+func TestTLSHandshakeWithTimeout_ContextCancellation(t *testing.T) {
+	// Create a TCP listener that accepts but never responds (simulates hanging server).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer ln.Close()
+
+	// Accept connections but do nothing — forces the TLS handshake to hang.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open but never send TLS data.
+			defer conn.Close()
+		}
+	}()
+
+	rawConn, err := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	client := &Client{
+		options: &clients.Options{Timeout: 5},
+	}
+
+	tlsConn := tls.Client(rawConn, &tls.Config{InsecureSkipVerify: true})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = client.tlsHandshakeWithTimeout(tlsConn, rawConn, ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	// The handshake should be interrupted within ~500ms (the context timeout),
+	// not hang indefinitely. Allow up to 2 seconds for CI jitter.
+	if elapsed > 2*time.Second {
+		t.Fatalf("handshake took %v, expected to be interrupted by context timeout (~500ms)", elapsed)
+	}
+}
+
+func TestCipherHandshakeContext_UsesConfiguredTimeout(t *testing.T) {
+	client := &Client{
+		options: &clients.Options{Timeout: 3},
+	}
+
+	ctx, cancel := client.cipherHandshakeContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected context with deadline")
+	}
+
+	remaining := time.Until(deadline)
+	if remaining < 2*time.Second || remaining > 4*time.Second {
+		t.Fatalf("expected ~3s deadline, got %v remaining", remaining)
+	}
+}
+
+func TestCipherHandshakeContext_DefaultsWhenZero(t *testing.T) {
+	client := &Client{
+		options: &clients.Options{Timeout: 0},
+	}
+
+	ctx, cancel := client.cipherHandshakeContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected context with deadline")
+	}
+
+	remaining := time.Until(deadline)
+	if remaining < 9*time.Second || remaining > 11*time.Second {
+		t.Fatalf("expected ~10s default deadline, got %v remaining", remaining)
+	}
+}


### PR DESCRIPTION
## Proposed changes

Fixes #819 — tlsx hangs indefinitely when processing large target lists (~25k+ hosts).

/claim #819

### Root causes

Three separate bugs cause the hang:

**1. ztls `tlsHandshakeWithTimeout` is broken (critical)**

```go
// BEFORE: Handshake() evaluates synchronously — select can never reach ctx.Done()
select {
case <-ctx.Done():
    return error  // never reached while Handshake blocks
case errChan <- tlsConn.Handshake():  // blocks here forever
}
```

Go evaluates `tlsConn.Handshake()` *before* attempting the channel send, so the `select` statement can never choose `ctx.Done()` while the handshake is blocking on an unresponsive server.

**Fix:** Run `Handshake()` in a goroutine. On timeout, close the underlying TCP connection to unblock the goroutine (closing the zcrypto TLS conn directly would deadlock on its internal mutex).

**2. ztls cipher enumeration uses `context.TODO()` (critical)**

```go
// BEFORE: no timeout — hangs forever if server doesn't respond
c.tlsHandshakeWithTimeout(conn, context.TODO())
```

Even with Bug 1 fixed, `context.TODO()` has no deadline, so cipher probes hang forever.

**Fix:** Create a timeout context from `c.options.Timeout` (default 10s fallback).

**3. Standard TLS cipher enumeration has no timeout (critical)**

```go
// BEFORE: bare Handshake() with no context
conn.Handshake()
```

**Fix:** Use `conn.HandshakeContext(ctx)` with a properly timed context.

### Changes

| File | Change |
|------|--------|
| `pkg/tlsx/ztls/ztls.go` | Fix `tlsHandshakeWithTimeout` to run handshake in goroutine; close raw conn on timeout; add `cipherHandshakeContext` helper; use it in `EnumerateCiphers` |
| `pkg/tlsx/tls/tls.go` | Add `cipherHandshakeContext` helper; use `HandshakeContext` in `EnumerateCiphers` |
| `pkg/tlsx/ztls/ztls_timeout_test.go` | Test: handshake interrupted in ~500ms (not hanging); context timeout helpers |
| `pkg/tlsx/tls/tls_timeout_test.go` | Test: context timeout helpers for ctls path |

### Proof

```
$ go test ./pkg/tlsx/ztls/ -run "TestTLSHandshakeWithTimeout|TestCipherHandshakeContext" -v
=== RUN   TestTLSHandshakeWithTimeout_ContextCancellation
--- PASS: TestTLSHandshakeWithTimeout_ContextCancellation (0.50s)
=== RUN   TestCipherHandshakeContext_UsesConfiguredTimeout
--- PASS: TestCipherHandshakeContext_UsesConfiguredTimeout (0.00s)
=== RUN   TestCipherHandshakeContext_DefaultsWhenZero
--- PASS: TestCipherHandshakeContext_DefaultsWhenZero (0.00s)
PASS

$ go test ./pkg/tlsx/tls/ -run "TestCipherHandshakeContext" -v
=== RUN   TestCipherHandshakeContext_UsesConfiguredTimeout
--- PASS: TestCipherHandshakeContext_UsesConfiguredTimeout (0.00s)
=== RUN   TestCipherHandshakeContext_DefaultsWhenZero
--- PASS: TestCipherHandshakeContext_DefaultsWhenZero (0.00s)
PASS
```

`go vet ./...` and `go build ./...` pass clean.

## Checklist

- [x] Pull request is created against the dev branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)