### PR TITLE
fix: split comma-separated entries in list file input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -208,6 +208,120 @@ func getTaskInputFromFile(filename string, ports []string) ([]taskInput, error) 
 	return ret, nil
 }
 
+func Test_CommaSeparatedListInput(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+	runner.hasStdin = false
+
+	// Create a temporary file with comma-separated entries on a single line
+	tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("www.example.com,www.example.org,www.example.net\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options.InputList = tmpFile.Name()
+
+	inputs := make(chan taskInput)
+	expected := []taskInput{
+		{host: "www.example.com", port: "443"},
+		{host: "www.example.org", port: "443"},
+		{host: "www.example.net", port: "443"},
+	}
+
+	go func() {
+		defer close(inputs)
+		err := runner.normalizeAndQueueInputs(inputs)
+		require.NoError(t, err)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "comma-separated entries in list file should be split into individual inputs")
+}
+
+func Test_CommaSeparatedListInputWithSpaces(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+	runner.hasStdin = false
+
+	// Create a temporary file with comma-separated entries that include spaces
+	tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("www.example.com , www.example.org , www.example.net\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options.InputList = tmpFile.Name()
+
+	inputs := make(chan taskInput)
+	expected := []taskInput{
+		{host: "www.example.com", port: "443"},
+		{host: "www.example.org", port: "443"},
+		{host: "www.example.net", port: "443"},
+	}
+
+	go func() {
+		defer close(inputs)
+		err := runner.normalizeAndQueueInputs(inputs)
+		require.NoError(t, err)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "comma-separated entries with spaces should be trimmed and split correctly")
+}
+
+func Test_MixedListInput(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+	runner.hasStdin = false
+
+	// Create a file with both single entries per line and comma-separated entries
+	tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("www.example.com\nwww.example.org,www.example.net\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options.InputList = tmpFile.Name()
+
+	inputs := make(chan taskInput)
+	expected := []taskInput{
+		{host: "www.example.com", port: "443"},
+		{host: "www.example.org", port: "443"},
+		{host: "www.example.net", port: "443"},
+	}
+
+	go func() {
+		defer close(inputs)
+		err := runner.normalizeAndQueueInputs(inputs)
+		require.NoError(t, err)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "mixed single-line and comma-separated entries should all be processed")
+}
+
 func Test_CTLogsModeValidation(t *testing.T) {
 	// Test that CT logs mode and input mode cannot be used together
 	// This validation is now done in the main package, so this test should be removed


### PR DESCRIPTION
## Summary

When targets are provided via `-l` (list file), each line is read as a single input string and passed directly to `processInputItem`. If a line contains comma-separated values like `192.168.1.0/24,192.168.2.0/24`, the entire string is treated as one host, causing a DNS resolution failure.

The `-u` flag handles this correctly because `goflags.CommaSeparatedStringSliceOptions` splits at the flag-parsing level, but that splitting never applies to file-based input.

## Changes

In `normalizeAndQueueInputs` (`internal/runner/runner.go`), each line read from the input file (and from stdin) is now split on commas. Each resulting item is trimmed of surrounding whitespace before being processed, so entries like `host1 , host2` work as expected.

Three unit tests are added covering:
- Basic comma-separated line splitting
- Comma-separated with surrounding whitespace
- Mixed file with both single-entry and comma-separated lines

## Test plan

- [x] New unit tests pass (`go test ./internal/runner/ -run "Test_CommaSeparated|Test_MixedList"`)
- [x] Full `internal/runner` test suite passes
- [x] `go vet ./...` clean

Fixes #859