### PR TITLE
fix: handle comma-separated entries in -l/-list file and stdin input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,9 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range splitAndTrim(text) {
+					r.processInputItem(item, inputs)
+				}
 			}
 		}
 	}
@@ -449,11 +451,35 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range splitAndTrim(text) {
+					r.processInputItem(item, inputs)
+				}
 			}
 		}
 	}
 	return nil
+}
+
+// splitAndTrim splits a string by comma and trims whitespace from each part,
+// returning only non-empty entries. If the input contains no commas, it returns
+// a single-element slice with the trimmed input.
+func splitAndTrim(input string) []string {
+	if !strings.Contains(input, ",") {
+		trimmed := strings.TrimSpace(input)
+		if trimmed == "" {
+			return nil
+		}
+		return []string{trimmed}
+	}
+	parts := strings.Split(input, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 // resolveFQDN resolves a FQDN and returns the IP addresses


### PR DESCRIPTION
## Description

When reading targets from a file (`-l`/`-list`) or stdin, comma-separated entries on a single line are now split and processed individually. This makes `-l` behavior consistent with `-u`, which already supports comma-separated inputs.

/claim #859

## Changes

### `internal/runner/runner.go`
- Updated file input scanning to split comma-separated entries before processing
- Updated stdin scanning with the same comma-split logic
- Added `splitAndTrim()` helper function that:
  - Splits input by comma delimiter
  - Trims whitespace from each part
  - Filters out empty entries
  - Returns single-element slice for non-comma inputs (zero overhead for normal usage)

## Testing

**Before:**
```
# targets.txt contains: 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24
tlsx -l targets.txt
# → tries to connect to '192.168.1.0/24,192.168.2.0/24,192.168.3.0/24' as one host → fails
```

**After:**
```
tlsx -l targets.txt
# → correctly processes each prefix individually: 192.168.1.0/24, 192.168.2.0/24, 192.168.3.0/24
```

## Checklist
- [x] Consistent with existing `-u` flag behavior
- [x] Backward compatible — single entries per line still work exactly as before
- [x] Handles whitespace around commas
- [x] Applies to both file input and stdin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input processing now supports comma-separated values on a single line from both input files and stdin, enabling multiple items per line with automatic whitespace trimming and blank value filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->