### PR TITLE
fix(ztls): fix hanging handshake by running in goroutine

### DIFF
--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -320,20 +320,22 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 	return config, nil
 }
 
-// tlsHandshakeWithCtx attempts tls handshake with given timeout
+// tlsHandshakeWithTimeout attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
+		// Close the connection to abort the handshake
+		_ = tlsConn.Close()
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			err = nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }


### PR DESCRIPTION
Fixes #819

### Problem
The `tlsHandshakeWithTimeout` function in `pkg/tlsx/ztls/ztls.go` was running the handshake synchronously within the `select` statement. This prevented the context timeout from being checked while the handshake was in progress, causing `tlsx` to hang indefinitely on certain network conditions.

### Solution
Run the handshake in a separate goroutine and select between the error channel and the context timeout. This ensures the timeout is always respected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TLS connection timeout handling with more reliable connection closure during timeout scenarios.
  * Enhanced internal concurrency management for better timeout behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->