### PR TITLE
fix: prevent indefinite hang on unresponsive TLS hosts

### DIFF
--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -236,10 +236,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 
 		conn := tls.Client(baseConn, baseCfg)
 
-		if err := conn.Handshake(); err == nil {
+		cipherCtx, cipherCancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		if err := conn.HandshakeContext(cipherCtx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
+		cipherCancel()
 		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -257,10 +257,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		cipherCtx, cipherCancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		if err := c.tlsHandshakeWithTimeout(conn, cipherCtx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
+		cipherCancel()
 		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil
@@ -320,20 +322,24 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 	return config, nil
 }
 
-// tlsHandshakeWithCtx attempts tls handshake with given timeout
+// tlsHandshakeWithTimeout attempts tls handshake with context-based timeout.
+// The handshake runs in a goroutine so the context cancellation can fire
+// even if the handshake itself blocks indefinitely.
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
+		// Close the underlying connection to unblock the hanging handshake goroutine.
+		_ = tlsConn.Close()
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }

--- a/pkg/tlsx/ztls/ztls_test.go
+++ b/pkg/tlsx/ztls/ztls_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	ctls "crypto/tls"
 
@@ -105,4 +107,66 @@ func TestClientCertRequired(t *testing.T) {
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+// TestHandshakeTimeout verifies that tlsx does not hang indefinitely
+// when connecting to a host that accepts TCP but never completes TLS.
+// Regression test for https://github.com/projectdiscovery/tlsx/issues/819
+func TestHandshakeTimeout(t *testing.T) {
+	// Start a TCP listener that accepts connections but never speaks TLS
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open but never send any data
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1024)
+				for {
+					if _, err := c.Read(buf); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	addr := ln.Addr().String()
+	host, port, _ := net.SplitHostPort(addr)
+
+	dialerOpts := fastdialer.DefaultOptions
+	dialerOpts.EnableFallback = false
+	fd, err := fastdialer.NewDialer(dialerOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := ztls.New(&clients.Options{
+		Timeout: 3, // 3 second timeout
+		Fastdialer: fd,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = client.ConnectWithOptions(host, host, port, clients.ConnectOptions{})
+	}()
+
+	select {
+	case <-done:
+		// Success: the connection returned (with error) within timeout
+	case <-time.After(10 * time.Second):
+		t.Fatal("tlsx hung indefinitely — handshake timeout not working")
+	}
 }


### PR DESCRIPTION
## Proposed Changes

Three bugs caused tlsx to hang indefinitely for certain hosts (those that accept TCP but have problematic TLS configurations):

### Bug 1: Broken `select` in ztls `tlsHandshakeWithTimeout()`

```go
// BEFORE (broken): Handshake() blocks synchronously, ctx.Done() never checked
select {
case <-ctx.Done():
    return error
case errChan <- tlsConn.Handshake():  // ← blocks here forever
}
```

```go
// AFTER: Handshake runs in goroutine, select properly races both channels
go func() { errChan <- tlsConn.Handshake() }()
select {
case <-ctx.Done():
    _ = tlsConn.Close() // unblock the goroutine
    return error
case err := <-errChan:
    return err
}
```

### Bug 2: ztls cipher enumeration used `context.TODO()` (no timeout)

Each cipher handshake attempt now uses `context.WithTimeout` based on the configured timeout.

### Bug 3: Standard tls cipher enumeration used bare `conn.Handshake()` (no timeout)

Changed to `conn.HandshakeContext(ctx)` with a proper timeout context.

## Proof

**Regression test** (`TestHandshakeTimeout`): Starts a local TCP listener that accepts connections but never speaks TLS (simulating the problematic hosts). Verifies tlsx returns within the configured timeout instead of hanging:

```
=== RUN   TestHandshakeTimeout
--- PASS: TestHandshakeTimeout (3.00s)
PASS
```

Without this fix, the test would hang for 10+ seconds and fail with "tlsx hung indefinitely".

## Checklist

- [x] PR created against the `dev` branch
- [x] All checks passed
- [x] Tests added that prove the fix is effective
- [x] Minimal, focused diff — only touches timeout/handshake paths

/claim #819