### PR TITLE
fix: support comma-separated inputs in -l list file and stdin

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Fixes #859

When reading targets from a file (`-l`) or stdin, each line is now split on commas, making the behavior consistent with the `-u` flag which already supports comma-separated inputs via `CommaSeparatedStringSliceOptions`.

## Changes

- Split comma-separated values when reading from `-l` list file
- Split comma-separated values when reading from stdin
- Trim whitespace around each item after splitting

## Before

```bash
# File: targets.txt contains: 192.168.1.0/24,192.168.2.0/24
tlsx -l targets.txt
# ERROR: Could not connect input 192.168.1.0/24,192.168.2.0/24:443
```

## After

```bash
# Same file now works correctly - each CIDR is processed individually
tlsx -l targets.txt
# Processes 192.168.1.0/24 and 192.168.2.0/24 separately
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input handling now supports multiple comma-separated items per line, with each item automatically expanded and processed individually across all input methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->