### PR TITLE
fix: handle comma-separated inputs in -l/stdin mode

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

When reading targets from a file (`-l`) or stdin, each line is now split on commas so that comma-separated entries (e.g. `192.168.1.0/24,192.168.2.0/24`) are processed individually, matching the existing behavior of `-u`.

## Problem

As reported in #859, using `-l` with a file containing comma-separated prefixes on a single line treats the entire line as one host, causing connection failures:

```
[WRN] Could not connect input 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24:443
```

## Fix

Split each line from file/stdin input on commas (with whitespace trimming) before passing to `processInputItem`, consistent with how `-u` handles `CommaSeparatedStringSliceOptions` via goflags.

Fixes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input processing now accepts comma-separated values per line, automatically trimming whitespace. Users can mix single-item and multi-item lines when providing input via files or standard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->