### PR TITLE
fix: handle comma-separated list input for -l flag

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -208,6 +208,77 @@ func getTaskInputFromFile(filename string, ports []string) ([]taskInput, error) 
 	return ret, nil
 }
 
+func Test_CommaSeparatedFileInput(t *testing.T) {
+	// Create a temporary file with comma-separated entries on a single line
+	tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("192.168.1.1,192.168.1.2,192.168.1.3\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options := &clients.Options{
+		Ports:     []string{"443"},
+		InputList: tmpFile.Name(),
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	expected := []taskInput{
+		{host: "192.168.1.1", port: "443"},
+		{host: "192.168.1.2", port: "443"},
+		{host: "192.168.1.3", port: "443"},
+	}
+
+	go func() {
+		_ = runner.normalizeAndQueueInputs(inputs)
+		close(inputs)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "comma-separated entries in file should be split into individual inputs")
+}
+
+func Test_CommaSeparatedFileInputMixedLines(t *testing.T) {
+	// Test file with a mix of single entries and comma-separated entries
+	tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("10.0.0.1\n10.0.0.2,10.0.0.3\n10.0.0.4\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options := &clients.Options{
+		Ports:     []string{"443"},
+		InputList: tmpFile.Name(),
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	expected := []taskInput{
+		{host: "10.0.0.1", port: "443"},
+		{host: "10.0.0.2", port: "443"},
+		{host: "10.0.0.3", port: "443"},
+		{host: "10.0.0.4", port: "443"},
+	}
+
+	go func() {
+		_ = runner.normalizeAndQueueInputs(inputs)
+		close(inputs)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "mixed single and comma-separated entries should all be processed")
+}
+
 func Test_CTLogsModeValidation(t *testing.T) {
 	// Test that CT logs mode and input mode cannot be used together
 	// This validation is now done in the main package, so this test should be removed


### PR DESCRIPTION
## Description
Fixes the `-l` flag to properly handle comma-separated list input.

When using `-l` with a file containing comma-separated entries on a single line (e.g., `192.168.1.0/24,192.168.2.0/24,192.168.3.0/24`), the entire line was incorrectly treated as a single target instead of being split into individual entries.

This change adds comma-splitting logic for both file input (`-l` flag) and stdin input, matching the existing behavior of the `-u` flag which already supports comma-separated values via `goflags.CommaSeparatedStringSliceOptions`.

### Changes
- Split comma-separated entries when reading from file input (`-l` flag)
- Split comma-separated entries when reading from stdin
- Added unit tests for comma-separated file input (single line and mixed lines)

### Proof

**Before:** A file containing `192.168.1.0/24,192.168.2.0/24` on a single line would be treated as one target, causing:
```
[WRN] Could not connect input 192.168.1.0/24,192.168.2.0/24:443 ... cause="no address found for host"
```

**After:** Each comma-separated entry is processed individually, matching `-u` flag behavior.

**Tests pass:**
```
=== RUN   Test_CommaSeparatedFileInput
--- PASS: Test_CommaSeparatedFileInput (0.00s)
=== RUN   Test_CommaSeparatedFileInputMixedLines
--- PASS: Test_CommaSeparatedFileInputMixedLines (0.00s)
PASS
```

### Checklist
- [x] PR created against the correct branch (`dev`)
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] Tests added that prove the fix is effective
- [x] Documentation added (if appropriate)

Closes #859

/claim #859