### PR TITLE
fix: run TLS handshake in goroutine to prevent indefinite hangs

### DIFF
--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -236,9 +236,17 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 
 		conn := tls.Client(baseConn, baseCfg)
 
-		if err := conn.Handshake(); err == nil {
+		cipherCtx := context.Background()
+		var cipherCancel context.CancelFunc
+		if c.options.Timeout != 0 {
+			cipherCtx, cipherCancel = context.WithTimeout(cipherCtx, time.Duration(c.options.Timeout)*time.Second)
+		}
+		if err := conn.HandshakeContext(cipherCtx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
+		}
+		if cipherCancel != nil {
+			cipherCancel()
 		}
 		_ = conn.Close() // close baseConn internally
 	}

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -257,9 +257,17 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		cipherCtx := context.Background()
+		var cipherCancel context.CancelFunc
+		if c.options.Timeout != 0 {
+			cipherCtx, cipherCancel = context.WithTimeout(cipherCtx, time.Duration(c.options.Timeout)*time.Second)
+		}
+		if err := c.tlsHandshakeWithTimeout(conn, cipherCtx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
+		}
+		if cipherCancel != nil {
+			cipherCancel()
 		}
 		_ = conn.Close() // also closes baseConn internally
 	}
@@ -320,20 +328,26 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 	return config, nil
 }
 
-// tlsHandshakeWithCtx attempts tls handshake with given timeout
+// tlsHandshakeWithTimeout attempts tls handshake with given timeout.
+// The handshake is run in a goroutine so that context cancellation/timeout
+// is properly respected. Without this, a hanging Handshake() call would
+// block the select and prevent ctx.Done() from ever firing.
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
+		// Force-close the underlying connection so the goroutine unblocks.
+		_ = tlsConn.Close()
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }


### PR DESCRIPTION
## Proposed Changes

Fix three separate timeout bugs that caused tlsx to hang indefinitely for some hosts during TLS handshake (#819).

### Bug 1: `ztls` `tlsHandshakeWithTimeout()` — broken select

`Handshake()` was called **synchronously** inside the `select case` expression:

```go
// BEFORE (broken): Handshake() blocks, preventing ctx.Done() from ever firing
select {
case <-ctx.Done():
    return error
case errChan <- tlsConn.Handshake():  // blocks here!
}
```

**Fix**: Run handshake in a goroutine so `select` can properly race between the handshake result and context cancellation:

```go
// AFTER (fixed): Handshake runs concurrently, timeout actually works
go func() {
    errChan <- tlsConn.Handshake()
}()
select {
case <-ctx.Done():
    _ = tlsConn.Close()  // unblock the goroutine
    return error
case err := <-errChan:
    return err
}
```

### Bug 2: `ztls` `EnumerateCiphers()` — missing timeout context

Used `context.TODO()` which has no deadline, making the timeout parameter completely ineffective:

```go
// BEFORE: no timeout at all
c.tlsHandshakeWithTimeout(conn, context.TODO())
// AFTER: proper timeout from options
ctx, cancel := context.WithTimeout(context.Background(), timeout)
c.tlsHandshakeWithTimeout(conn, ctx)
```

### Bug 3: `tls` `EnumerateCiphers()` — bare Handshake() with no context

Used `conn.Handshake()` instead of `conn.HandshakeContext(ctx)`, ignoring timeouts entirely:

```go
// BEFORE: no timeout, can hang forever
conn.Handshake()
// AFTER: respects configured timeout
conn.HandshakeContext(ctx)
```

## Proof

Build passes with zero errors:
```
$ go build ./...
(no output — success)
```

## Checklist

- [x] PR created against the correct branch (main)
- [x] All checks passed (go build ./... succeeds with no errors)
- [x] Code changes are minimal and focused on the bug fix
- [x] All three handshake timeout paths are fixed

/claim #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TLS cipher enumeration now enforces per-operation timeouts to avoid stalled handshakes.
  * Improved timeout handling ensures connections are cleaned up promptly on timeout, preventing indefinite hangs and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->