### PR TITLE
fix: split comma-separated entries when reading from file input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -419,6 +419,16 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 }
 
 // normalizeAndQueueInputs normalizes the inputs and queues them for execution
+// processLine splits a comma-separated input line and queues each non-empty item.
+func (r *Runner) processLine(text string, inputs chan taskInput) {
+	for _, item := range strings.Split(text, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			r.processInputItem(item, inputs)
+		}
+	}
+}
+
 func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 	// Process Normal Inputs
 	for _, text := range r.options.Inputs {
@@ -440,12 +450,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				for _, item := range strings.Split(text, ",") {
-					item = strings.TrimSpace(item)
-					if item != "" {
-						r.processInputItem(item, inputs)
-					}
-				}
+				r.processLine(text, inputs)
 			}
 		}
 	}
@@ -454,12 +459,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				for _, item := range strings.Split(text, ",") {
-					item = strings.TrimSpace(item)
-					if item != "" {
-						r.processInputItem(item, inputs)
-					}
-				}
+				r.processLine(text, inputs)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #859
The `-u` flag correctly splits comma-separated values via `CommaSeparatedStringSliceOptions`, but `-l` and stdin pass entire lines to `processInputItem` without splitting.

Added `strings.Split(text, ",")` to both the file reader and stdin reader in `normalizeAndQueueInputs`, matching the behavior of `-u`.

Before:
echo '192.168.1.0/24,192.168.2.0/24' > targets.txt
tlsx -l targets.txt  # treats entire line as one target

After:
tlsx -l targets.txt  # splits and processes each entry separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Input processing now accepts comma-separated items within each line for both file and standard-input sources. Multiple entries on a single line are split, trimmed of surrounding whitespace, and empty items are ignored — simplifying bulk entry and reducing manual formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->