### PR TITLE
fix: split comma-separated entries when reading from -l file or stdin

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Fixes #859

When using `-u`, comma-separated targets work correctly:
```
./tlsx -u 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24
```

But when using `-l` with a file containing the same comma-separated targets on one line, the entire line is treated as a single host, causing:
```
[WRN] Could not connect input 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24:443
```

## Fix

Split each line by commas and trim whitespace when reading from file (`-l`) or stdin input, then process each entry individually. This makes `-l` and stdin behavior consistent with `-u`.

## Changes

- `internal/runner/runner.go`: Split comma-separated entries in file and stdin input processing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Input parsing enhanced to support comma-separated values on a single line. Each value is now processed as a separate input with automatic whitespace trimming, allowing more flexible input formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->