### PR TITLE
fix: bound TLS cipher enumeration handshake by timeout

### DIFF
--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -235,11 +235,13 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		baseCfg.CipherSuites = []uint16{tlsCiphers[v]}
 
 		conn := tls.Client(baseConn, baseCfg)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
 
-		if err := conn.Handshake(); err == nil {
+		if err := conn.HandshakeContext(ctx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
+		cancel()
 		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -257,10 +257,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		if err := c.tlsHandshakeWithTimeout(conn, ctx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
+		cancel()
 		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil
@@ -323,17 +325,19 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
+		_ = tlsConn.Close()
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }


### PR DESCRIPTION
/claim #819

## Summary
- fix infinite hang during cipher enumeration in `pkg/tlsx/tls` by using `HandshakeContext` with `options.Timeout`
- fix the same hang class in `pkg/tlsx/ztls` by passing a timeout context into `tlsHandshakeWithTimeout`
- close timed-out ztls connections immediately to avoid leaked blocked handshakes
- preserve existing behavior for successful handshakes and `tls.ErrCertsOnly`

## Why
Algora bounty issue reports `tlsx` hanging indefinitely for some hosts. The root cause is per-cipher handshake attempts without an enforced handshake timeout in enumeration paths.

## Verification
- `go test ./pkg/tlsx`
- `go test ./pkg/tlsx/clients`

## Linked issue
- Closes #819


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connection timeout handling to properly enforce configured timeouts during handshake operations.
  * Enhanced error handling and reliability for TLS certificate validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->