### PR TITLE
fix: enforce timeout in ctls/ztls cipher enumeration handshakes

### DIFF
--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -239,14 +239,13 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 			if err != nil {
 				return errorutil.NewWithErr(err).WithTag("ctls") //nolint
 			}
-			stats.IncrementCryptoTLSConnections()
-
 			cfg := baseCfg.Clone()
 			cfg.CipherSuites = []uint16{tlsCiphers[v]}
 			conn := tls.Client(baseConn, cfg)
 			defer func() { _ = conn.Close() }() // close baseConn internally
 
 			if err := conn.HandshakeContext(handshakeCtx); err == nil {
+				stats.IncrementCryptoTLSConnections()
 				ciphersuite := conn.ConnectionState().CipherSuite
 				enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 			}

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -226,30 +226,35 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 	}()
 
 	for _, v := range toEnumerate {
-		handshakeCtx := context.Background()
-		cancel := func() {}
-		if c.options.Timeout != 0 {
-			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
-		}
+		err := func(v string) error {
+			handshakeCtx := context.Background()
+			cancel := func() {}
+			if c.options.Timeout != 0 {
+				handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+			}
+			defer cancel()
 
-		// create new baseConn and pass it to tlsclient
-		baseConn, err := pool.Acquire(handshakeCtx)
+			// create new baseConn and pass it to tlsclient
+			baseConn, err := pool.Acquire(handshakeCtx)
+			if err != nil {
+				return errorutil.NewWithErr(err).WithTag("ctls") //nolint
+			}
+			stats.IncrementCryptoTLSConnections()
+
+			cfg := baseCfg.Clone()
+			cfg.CipherSuites = []uint16{tlsCiphers[v]}
+			conn := tls.Client(baseConn, cfg)
+			defer func() { _ = conn.Close() }() // close baseConn internally
+
+			if err := conn.HandshakeContext(handshakeCtx); err == nil {
+				ciphersuite := conn.ConnectionState().CipherSuite
+				enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
+			}
+			return nil
+		}(v)
 		if err != nil {
-			cancel()
-			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ctls") //nolint
+			return enumeratedCiphers, err
 		}
-		stats.IncrementCryptoTLSConnections()
-
-		cfg := baseCfg.Clone()
-		cfg.CipherSuites = []uint16{tlsCiphers[v]}
-		conn := tls.Client(baseConn, cfg)
-
-		if err := conn.HandshakeContext(handshakeCtx); err == nil {
-			ciphersuite := conn.ConnectionState().CipherSuite
-			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
-		}
-		cancel()
-		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil
 }

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -226,20 +226,29 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 	}()
 
 	for _, v := range toEnumerate {
+		handshakeCtx := context.Background()
+		cancel := func() {}
+		if c.options.Timeout != 0 {
+			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		}
+
 		// create new baseConn and pass it to tlsclient
-		baseConn, err := pool.Acquire(context.Background())
+		baseConn, err := pool.Acquire(handshakeCtx)
 		if err != nil {
+			cancel()
 			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ctls") //nolint
 		}
 		stats.IncrementCryptoTLSConnections()
-		baseCfg.CipherSuites = []uint16{tlsCiphers[v]}
 
-		conn := tls.Client(baseConn, baseCfg)
+		cfg := baseCfg.Clone()
+		cfg.CipherSuites = []uint16{tlsCiphers[v]}
+		conn := tls.Client(baseConn, cfg)
 
-		if err := conn.Handshake(); err == nil {
+		if err := conn.HandshakeContext(handshakeCtx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
+		cancel()
 		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil

--- a/pkg/tlsx/ztls/timeout_test.go
+++ b/pkg/tlsx/ztls/timeout_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestTLSHandshakeWithTimeout_ContextDeadline(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
 	defer serverConn.Close()
 
 	conn := ztls.Client(clientConn, &ztls.Config{ServerName: "example.com", InsecureSkipVerify: true})
@@ -20,7 +21,7 @@ func TestTLSHandshakeWithTimeout_ContextDeadline(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := client.tlsHandshakeWithTimeout(conn, ctx)
+	err := client.tlsHandshakeWithTimeout(ctx, conn)
 	elapsed := time.Since(start)
 
 	if err == nil {

--- a/pkg/tlsx/ztls/timeout_test.go
+++ b/pkg/tlsx/ztls/timeout_test.go
@@ -1,0 +1,32 @@
+package ztls
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	ztls "github.com/zmap/zcrypto/tls"
+)
+
+func TestTLSHandshakeWithTimeout_ContextDeadline(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	conn := ztls.Client(clientConn, &ztls.Config{ServerName: "example.com", InsecureSkipVerify: true})
+	client := &Client{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := client.tlsHandshakeWithTimeout(conn, ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("handshake timeout took too long: %s", elapsed)
+	}
+}

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -249,29 +249,34 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 	gologger.Debug().Label("ztls").Msgf("Starting cipher enumeration with %v ciphers in %v", len(toEnumerate), options.VersionTLS)
 
 	for _, v := range toEnumerate {
-		handshakeCtx := context.Background()
-		cancel := func() {}
-		if c.options.Timeout != 0 {
-			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
-		}
+		err := func(v string) error {
+			handshakeCtx := context.Background()
+			cancel := func() {}
+			if c.options.Timeout != 0 {
+				handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+			}
+			defer cancel()
 
-		baseConn, err := pool.Acquire(handshakeCtx)
+			baseConn, err := pool.Acquire(handshakeCtx)
+			if err != nil {
+				return errorutil.NewWithErr(err).WithTag("ztls") //nolint
+			}
+			stats.IncrementZcryptoTLSConnections()
+
+			cfg := baseCfg.Clone()
+			cfg.CipherSuites = []uint16{ztlsCiphers[v]}
+			conn := tls.Client(baseConn, cfg)
+			defer func() { _ = conn.Close() }() // also closes baseConn internally
+
+			if err := c.tlsHandshakeWithTimeout(conn, handshakeCtx); err == nil {
+				h1 := conn.GetHandshakeLog()
+				enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
+			}
+			return nil
+		}(v)
 		if err != nil {
-			cancel()
-			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ztls") //nolint
+			return enumeratedCiphers, err
 		}
-		stats.IncrementZcryptoTLSConnections()
-
-		cfg := baseCfg.Clone()
-		cfg.CipherSuites = []uint16{ztlsCiphers[v]}
-		conn := tls.Client(baseConn, cfg)
-
-		if err := c.tlsHandshakeWithTimeout(conn, handshakeCtx); err == nil {
-			h1 := conn.GetHandshakeLog()
-			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
-		}
-		cancel()
-		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil
 }

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -140,7 +140,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 	// new tls connection
 	tlsConn := tls.Client(conn, config)
-	err = c.tlsHandshakeWithTimeout(tlsConn, ctx)
+	err = c.tlsHandshakeWithTimeout(ctx, tlsConn)
 	if err != nil {
 		if clients.IsClientCertRequiredError(err) {
 			clientCertRequired = true
@@ -268,7 +268,7 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 			conn := tls.Client(baseConn, cfg)
 			defer func() { _ = conn.Close() }() // also closes baseConn internally
 
-			if err := c.tlsHandshakeWithTimeout(conn, handshakeCtx); err == nil {
+			if err := c.tlsHandshakeWithTimeout(handshakeCtx, conn); err == nil {
 				h1 := conn.GetHandshakeLog()
 				enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 			}
@@ -335,8 +335,8 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 	return config, nil
 }
 
-// tlsHandshakeWithCtx attempts tls handshake with given timeout
-func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
+// tlsHandshakeWithTimeout attempts tls handshake with given timeout
+func (c *Client) tlsHandshakeWithTimeout(ctx context.Context, tlsConn *tls.Conn) error {
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- tlsConn.Handshake()
@@ -347,7 +347,7 @@ func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context)
 		_ = tlsConn.SetDeadline(time.Now())
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
 	case err := <-errChan:
-		if err == tls.ErrCertsOnly {
+		if errors.Is(err, tls.ErrCertsOnly) {
 			return nil
 		}
 		return err

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -261,16 +261,17 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 			if err != nil {
 				return errorutil.NewWithErr(err).WithTag("ztls") //nolint
 			}
-			stats.IncrementZcryptoTLSConnections()
-
 			cfg := baseCfg.Clone()
 			cfg.CipherSuites = []uint16{ztlsCiphers[v]}
 			conn := tls.Client(baseConn, cfg)
 			defer func() { _ = conn.Close() }() // also closes baseConn internally
 
 			if err := c.tlsHandshakeWithTimeout(handshakeCtx, conn); err == nil {
+				stats.IncrementZcryptoTLSConnections()
 				h1 := conn.GetHandshakeLog()
-				enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
+				if h1 != nil && h1.ServerHello != nil {
+					enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
+				}
 			}
 			return nil
 		}(v)
@@ -337,6 +338,10 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 
 // tlsHandshakeWithTimeout attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(ctx context.Context, tlsConn *tls.Conn) error {
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = tlsConn.SetDeadline(deadline)
+	}
+
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- tlsConn.Handshake()

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -249,18 +249,28 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 	gologger.Debug().Label("ztls").Msgf("Starting cipher enumeration with %v ciphers in %v", len(toEnumerate), options.VersionTLS)
 
 	for _, v := range toEnumerate {
-		baseConn, err := pool.Acquire(context.Background())
+		handshakeCtx := context.Background()
+		cancel := func() {}
+		if c.options.Timeout != 0 {
+			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		}
+
+		baseConn, err := pool.Acquire(handshakeCtx)
 		if err != nil {
+			cancel()
 			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ztls") //nolint
 		}
 		stats.IncrementZcryptoTLSConnections()
-		conn := tls.Client(baseConn, baseCfg)
-		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		cfg := baseCfg.Clone()
+		cfg.CipherSuites = []uint16{ztlsCiphers[v]}
+		conn := tls.Client(baseConn, cfg)
+
+		if err := c.tlsHandshakeWithTimeout(conn, handshakeCtx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
+		cancel()
 		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil
@@ -323,17 +333,18 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
+		_ = tlsConn.SetDeadline(time.Now())
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }


### PR DESCRIPTION
## Proposed Changes
This PR tightens timeout enforcement during cipher enumeration to prevent indefinite hangs in both `ctls` and `ztls` paths.

### What changed
- `pkg/tlsx/tls/tls.go`
  - Uses per-cipher timeout context (`context.WithTimeout`) when `options.Timeout` is set.
  - Uses `HandshakeContext` so timeout is honored during TLS handshake.
  - Uses cloned TLS config per iteration before setting `CipherSuites`.
- `pkg/tlsx/ztls/ztls.go`
  - Uses per-cipher timeout context for pool acquire + handshake.
  - `tlsHandshakeWithTimeout` now runs handshake in goroutine and exits on context cancellation.
  - On timeout, sets connection deadline to unblock pending handshake I/O.
  - Uses cloned config per cipher iteration.
- `pkg/tlsx/ztls/timeout_test.go`
  - Adds regression test proving context deadline is enforced (`TestTLSHandshakeWithTimeout_ContextDeadline`).

## Proof
Focused local verification:

```bash
go test ./pkg/tlsx/ztls -run TestTLSHandshakeWithTimeout_ContextDeadline -count=1
# ok

go test ./pkg/tlsx/tls -run TestNonExistent -count=1
# ok (compile check for changed ctls path)
```

## Checklist
- [x] PR created against correct branch
- [x] Tests added/updated for fix behavior
- [x] Focused verification run locally
- [x] No unrelated changes

/claim #819


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS handshake timeout enforcement and per-connection cleanup to reduce hangs and improve reliability of TLS interactions.
  * More reliable per-cipher handshake handling and clearer error reporting during TLS negotiations.

* **Tests**
  * Added test coverage validating TLS handshake timeout behavior and timing bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->