### PR TITLE
fix(ztls): enforce handshake timeout and propagate output write errors

### DIFF
--- a/ALGORA_819_REPORT.md
+++ b/ALGORA_819_REPORT.md
@@ -1,0 +1,55 @@
+# tlsx Issue #819 Patch Report
+
+## Root Cause Hypothesis
+- Primary hang cause: `ztls` timeout wrapper did not actually enforce timeout. In `pkg/tlsx/ztls/ztls.go`, `tlsConn.Handshake()` was executed inline inside a `select` send expression, so the call could block forever before `ctx.Done()` was checked.
+- This can stall worker goroutines indefinitely for problematic hosts, which matches the issue symptoms.
+- Truncated JSONL lines are likely a downstream effect when users terminate a hung scan mid-write.
+- Secondary correctness bug: output file write errors were wrapped with the wrong variable (`err` instead of `writeErr`) in `pkg/output/output.go`, which could hide write failures.
+
+## Changes
+1. Fixed ztls handshake timeout behavior (`pkg/tlsx/ztls/ztls.go:324`)
+- Run `tlsConn.Handshake()` in a goroutine and wait on either:
+  - handshake completion, or
+  - context deadline/cancel.
+- On timeout, force-close `tlsConn` before returning timeout error to unblock any in-flight handshake.
+
+2. Added regression test for handshake timeout (`pkg/tlsx/ztls/ztls_timeout_test.go:12`)
+- New test uses `net.Pipe()` with an idle peer so handshake blocks.
+- Asserts `tlsHandshakeWithTimeout` returns promptly on context deadline (instead of hanging).
+
+3. Fixed output write error propagation (`pkg/output/output.go:94`)
+- Changed `errkit.Wrap(err, ...)` to `errkit.Wrap(writeErr, ...)` so file write failures are not swallowed.
+
+4. Added regression test for output write error propagation (`pkg/output/output_test.go:29`)
+- Constructs a writer with a closed temp file and verifies `Write` returns an error.
+
+## Validation Commands + Outputs
+Executed from repo root (`/home/ubuntu/repos/personal_openclaw/workspace/bounties/tlsx`):
+
+1. `go test ./pkg/tlsx/ztls -run TestTLSHandshakeWithTimeoutReturnsOnContextDeadline -count=1`
+- Output:
+  - `go: downloading go1.24.0 (linux/amd64)`
+  - `go: download go1.24.0: ... permission denied` (initial cache path)
+
+2. `GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go test ./pkg/tlsx/ztls -run TestTLSHandshakeWithTimeoutReturnsOnContextDeadline -count=1`
+- Output:
+  - `go: downloading go1.24.0 (linux/amd64)`
+  - `go: download go1.24.0: ... Get "https://proxy.golang.org/...": ... socket: operation not permitted`
+
+3. `GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go test ./...`
+- Output:
+  - same toolchain download/network restriction error as above.
+
+4. `GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go build ./cmd/tlsx`
+- Output:
+  - same toolchain download/network restriction error as above.
+
+5. `gofmt -w pkg/output/output.go pkg/output/output_test.go pkg/tlsx/ztls/ztls.go pkg/tlsx/ztls/ztls_timeout_test.go`
+- Output: success (no errors).
+
+## Limitations
+- Full test/build verification could not be completed in this sandbox because:
+  - `go.mod` requires Go `1.24.0`,
+  - local toolchain is `go1.22.2`,
+  - automatic toolchain download is blocked by sandbox network restrictions.
+- The patch is intentionally minimal and targeted to the identified indefinite-hang path in `ztls` plus one output error-propagation bug.

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -92,7 +92,7 @@ func (w *StandardWriter) Write(event *clients.Response) error {
 			data = decolorizerRegex.ReplaceAll(data, []byte(""))
 		}
 		if writeErr := w.outputFile.Write(data); writeErr != nil {
-			return errkit.Wrap(err, "could not write to output")
+			return errkit.Wrap(writeErr, "could not write to output")
 		}
 	}
 	return nil

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -1,6 +1,9 @@
 package output
 
 import (
+	"bufio"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/projectdiscovery/tlsx/pkg/tlsx/clients"
@@ -21,4 +24,20 @@ func TestStandardWriter_formatStandard(t *testing.T) {
 		require.Nil(t, out)
 		require.Error(t, err)
 	})
+}
+
+func TestStandardWriter_WriteReturnsFileWriteError(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "output-test-*")
+	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
+
+	writer := &StandardWriter{
+		json:        true,
+		outputFile:  &fileWriter{file: tempFile, writer: bufio.NewWriterSize(tempFile, 1)},
+		outputMutex: &sync.Mutex{},
+		options:     &clients.Options{},
+	}
+
+	err = writer.Write(&clients.Response{Host: "example.com-very-long-host-to-force-buffer-flush", Port: "443"})
+	require.Error(t, err)
 }

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -323,15 +323,19 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
+	var err error
 	select {
 	case <-ctx.Done():
+		// Ensure any blocked handshake is interrupted and does not leak indefinitely.
+		// Close can block in some states, so do it asynchronously.
+		go func() { _ = tlsConn.Close() }()
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err = <-errChan:
 	}
-
-	err := <-errChan
 	if err == tls.ErrCertsOnly {
 		err = nil
 	}

--- a/pkg/tlsx/ztls/ztls_timeout_test.go
+++ b/pkg/tlsx/ztls/ztls_timeout_test.go
@@ -1,0 +1,42 @@
+package ztls
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/zmap/zcrypto/tls"
+)
+
+func TestTLSHandshakeWithTimeoutReturnsOnContextDeadline(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+
+	tlsConn := tls.Client(clientConn, &tls.Config{
+		ServerName:         "example.com",
+		InsecureSkipVerify: true,
+	})
+
+	client := &Client{}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- client.tlsHandshakeWithTimeout(tlsConn, ctx)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected timeout error, got nil")
+		}
+		if time.Since(start) > time.Second {
+			t.Fatalf("handshake timeout took too long: %s", time.Since(start))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handshake did not return on context deadline")
+	}
+}


### PR DESCRIPTION
# tlsx Issue #819 Patch Report

## Root Cause Hypothesis
- Primary hang cause: `ztls` timeout wrapper did not actually enforce timeout. In `pkg/tlsx/ztls/ztls.go`, `tlsConn.Handshake()` was executed inline inside a `select` send expression, so the call could block forever before `ctx.Done()` was checked.
- This can stall worker goroutines indefinitely for problematic hosts, which matches the issue symptoms.
- Truncated JSONL lines are likely a downstream effect when users terminate a hung scan mid-write.
- Secondary correctness bug: output file write errors were wrapped with the wrong variable (`err` instead of `writeErr`) in `pkg/output/output.go`, which could hide write failures.

## Changes
1. Fixed ztls handshake timeout behavior (`pkg/tlsx/ztls/ztls.go:324`)
- Run `tlsConn.Handshake()` in a goroutine and wait on either:
  - handshake completion, or
  - context deadline/cancel.
- On timeout, force-close `tlsConn` before returning timeout error to unblock any in-flight handshake.

2. Added regression test for handshake timeout (`pkg/tlsx/ztls/ztls_timeout_test.go:12`)
- New test uses `net.Pipe()` with an idle peer so handshake blocks.
- Asserts `tlsHandshakeWithTimeout` returns promptly on context deadline (instead of hanging).

3. Fixed output write error propagation (`pkg/output/output.go:94`)
- Changed `errkit.Wrap(err, ...)` to `errkit.Wrap(writeErr, ...)` so file write failures are not swallowed.

4. Added regression test for output write error propagation (`pkg/output/output_test.go:29`)
- Constructs a writer with a closed temp file and verifies `Write` returns an error.

## Validation Commands + Outputs
Executed from repo root (`/home/ubuntu/repos/personal_openclaw/workspace/bounties/tlsx`):

1. `go test ./pkg/tlsx/ztls -run TestTLSHandshakeWithTimeoutReturnsOnContextDeadline -count=1`
- Output:
  - `go: downloading go1.24.0 (linux/amd64)`
  - `go: download go1.24.0: ... permission denied` (initial cache path)

2. `GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go test ./pkg/tlsx/ztls -run TestTLSHandshakeWithTimeoutReturnsOnContextDeadline -count=1`
- Output:
  - `go: downloading go1.24.0 (linux/amd64)`
  - `go: download go1.24.0: ... Get "https://proxy.golang.org/...": ... socket: operation not permitted`

3. `GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go test ./...`
- Output:
  - same toolchain download/network restriction error as above.

4. `GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go build ./cmd/tlsx`
- Output:
  - same toolchain download/network restriction error as above.

5. `gofmt -w pkg/output/output.go pkg/output/output_test.go pkg/tlsx/ztls/ztls.go pkg/tlsx/ztls/ztls_timeout_test.go`
- Output: success (no errors).

## Limitations
- Full test/build verification could not be completed in this sandbox because:
  - `go.mod` requires Go `1.24.0`,
  - local toolchain is `go1.22.2`,
  - automatic toolchain download is blocked by sandbox network restrictions.
- The patch is intentionally minimal and targeted to the identified indefinite-hang path in `ztls` plus one output error-propagation bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed output write error propagation to properly report write failures instead of silently ignoring them
  * Enhanced TLS handshake handling with timeout awareness to prevent indefinite blocking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->