### PR TITLE
fix(openssl): add dial timeout to avoid indefinite hangs (Fixes #819)

### DIFF
--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -54,9 +54,13 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 			return nil, errorutils.NewWithErr(err).WithTag(PkgTag, "fastdialer").Msgf("failed to create new fastdialer") //nolint
 		}
 	}
+	// Use a single timeout context for both dialing and openssl execution.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+	defer cancel()
+
 	// There is no guarantee that dialed ip is same as ip used by openssl
 	// this is only used to avoid inconsistencies
-	rawConn, err := c.dialer.Dial(context.TODO(), "tcp", opensslOpts.Address)
+	rawConn, err := c.dialer.Dial(ctx, "tcp", opensslOpts.Address)
 	if err != nil || rawConn == nil {
 		return nil, errorutils.NewWithErr(err).WithTag(PkgTag, "fastdialer").Msgf("could not dial address:%v", opensslOpts.Address) //nolint
 	}
@@ -68,8 +72,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(c.options.Timeout)*time.Second)
-	defer cancel()
+
 	// Here _ contains handshake errors and other errors returned by openssl
 	resp, errx := getResponse(ctx, opensslOpts)
 	if errx != nil {


### PR DESCRIPTION
Fixes #819

Context:
Some hosts can cause the auto→openssl fallback path to hang indefinitely. The underlying dial uses context.TODO(), so a stuck connect can block the entire scan.

Changes:
- Use a unified context.WithTimeout to bound both the dial and the openssl execution path.
- This prevents indefinite hangs and makes behavior consistent with other timeout-controlled code paths.

Tests:
- go test ./... -run "^$" -count=1 (build-only)

/claim #819