### PR TITLE
fix: -l -list option does not understand multiple prefixes comma-separated

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes #859

/claim #859

## Description

This PR addresses the issue: -l -list option does not understand multiple prefixes comma-separated

See https://github.com/projectdiscovery/tlsx/issues/859 for details.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input lines can now contain multiple comma-separated items, with each item individually processed. This enhancement applies to both file-based and STDIN inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->