### PR TITLE
fix: handle comma-separated entries in -l/--list input file

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Fix

Resolves #859 — the `-l`/`--list` flag now handles comma-separated entries within a single line, matching the behavior of `-u`.

/claim #859

### Problem

When using `-l filename.txt` where the file contains comma-separated prefixes on a single line (e.g. `192.168.1.0/24,192.168.2.0/24,192.168.3.0/24`), tlsx tried to use the entire comma-separated string as a single host, resulting in:

```
[WRN] Could not connect input 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24:443
```

### Changes

In `normalizeAndQueueInputs()` (`internal/runner/runner.go`), lines read from the input file and stdin are now split by comma before processing:

- Single entries per line: unchanged behavior (`strings.Split` returns one-element slice)
- Comma-separated entries: split and processed individually
- Whitespace around commas: handled via `strings.TrimSpace`
- Empty items from trailing commas: skipped

### Testing

- `go build ./...` passes
- Consistent with how `-u` handles comma-separated inputs via `goflags.CommaSeparatedStringSliceOptions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input processing now supports comma-separated values on individual lines. Both file-based and standard input sources can handle multiple items per line with automatic whitespace trimming and empty value filtering, improving input handling flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->