### PR TITLE
fix(runner): accept raw IPv6 inputs without treating as host:port

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -528,20 +528,48 @@ func (r *Runner) getHostPortFromInput(input string) (string, string) {
 	host := input
 
 	if strings.Contains(input, "://") {
-		if parsed, err := url.Parse(input); err != nil {
+		parsed, err := url.Parse(input)
+		if err != nil {
 			return "", ""
-		} else {
-			host = parsed.Host
+		}
+		host = parsed.Host
+	}
+
+	// net.SplitHostPort requires bracketed IPv6 literals. If the user provides
+	// something like "2a03:2880:...:1" or "[2a03:...:1]:443" we want to accept
+	// it without failing parsing.
+	host, port := splitHostPortLoose(host)
+	return host, port
+}
+
+func splitHostPortLoose(hostport string) (string, string) {
+	// Fast path: valid host:port, including bracketed IPv6.
+	if h, p, err := net.SplitHostPort(hostport); err == nil {
+		return h, p
+	}
+
+	// If it doesn't look like a port suffix, keep as-is.
+	lastColon := strings.LastIndex(hostport, ":")
+	if lastColon <= 0 || lastColon >= len(hostport)-1 {
+		return hostport, ""
+	}
+	portPart := hostport[lastColon+1:]
+	if portPart == "" {
+		return hostport, ""
+	}
+	for i := 0; i < len(portPart); i++ {
+		if portPart[i] < '0' || portPart[i] > '9' {
+			return hostport, ""
 		}
 	}
-	if strings.Contains(host, ":") {
-		if host, port, err := net.SplitHostPort(host); err != nil {
-			return "", ""
-		} else {
-			return host, port
-		}
+
+	// If there is only one colon, this is probably host:port already.
+	if strings.Count(hostport, ":") == 1 {
+		return hostport[:lastColon], portPart
 	}
-	return host, ""
+
+	// Multiple colons: treat as raw IPv6 literal with no explicit port.
+	return hostport, ""
 }
 
 // processInputASN processes a single ASN input

--- a/internal/runner/runner_hostport_test.go
+++ b/internal/runner/runner_hostport_test.go
@@ -1,0 +1,37 @@
+package runner
+
+import "testing"
+
+func TestGetHostPortFromInput(t *testing.T) {
+	t.Parallel()
+
+	r := &Runner{}
+
+	tests := []struct {
+		name        string
+		input       string
+		wantHost    string
+		wantPort    string
+	}{
+		{name: "domain", input: "example.com", wantHost: "example.com", wantPort: ""},
+		{name: "domain-port", input: "example.com:8443", wantHost: "example.com", wantPort: "8443"},
+		{name: "https-url", input: "https://example.com:8443/path", wantHost: "example.com", wantPort: "8443"},
+		{name: "ipv4", input: "1.2.3.4", wantHost: "1.2.3.4", wantPort: ""},
+		{name: "ipv4-port", input: "1.2.3.4:443", wantHost: "1.2.3.4", wantPort: "443"},
+		{name: "ipv6", input: "2a03:2880:11ff:17::face:b00c", wantHost: "2a03:2880:11ff:17::face:b00c", wantPort: ""},
+		{name: "ipv6-bracket-port", input: "[2a03:2880:11ff:17::face:b00c]:443", wantHost: "2a03:2880:11ff:17::face:b00c", wantPort: "443"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			host, port := r.getHostPortFromInput(tt.input)
+			if host != tt.wantHost {
+				t.Fatalf("host mismatch: want=%q got=%q", tt.wantHost, host)
+			}
+			if port != tt.wantPort {
+				t.Fatalf("port mismatch: want=%q got=%q", tt.wantPort, port)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #859.

When passing an IPv6 literal like `2a03:2880:11ff:17::face:b00c` (no brackets) as input, the runner treated it as `host:port` and failed parsing.

This change:
- Parses the input URL (if any) and then uses a loose host/port split.
- Accepts bracketed IPv6 with port (`[...]:443`) and classic `host:port`.
- Treats multi-colon unbracketed values as IPv6 literals with no explicit port.

Added a small unit test covering domain, IPv4, IPv6, and bracketed IPv6+port.