### PR TITLE
fix(list): support comma-separated prefixes in -l input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -456,8 +456,16 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			text := scanner.Text()
-			if text != "" {
-				r.processInputItem(text, inputs)
+			if text == "" {
+				continue
+			}
+
+			for _, item := range strings.Split(text, ",") {
+				item = strings.TrimSpace(item)
+				if item == "" {
+					continue
+				}
+				r.processInputItem(item, inputs)
 			}
 		}
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -468,6 +468,9 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 				r.processInputItem(item, inputs)
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			return errkit.Wrap(err, "could not read stdin")
+		}
 	}
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -439,8 +439,16 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			text := scanner.Text()
-			if text != "" {
-				r.processInputItem(text, inputs)
+			if text == "" {
+				continue
+			}
+
+			for _, item := range strings.Split(text, ",") {
+				item = strings.TrimSpace(item)
+				if item == "" {
+					continue
+				}
+				r.processInputItem(item, inputs)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #859

When targets are provided via `-l` and a line contains multiple comma-separated CIDRs/hosts, tlsx treated the whole line as a single host.

This change splits each non-empty line on commas, trims whitespace, and processes each entry individually (same behavior as `-u`).

Notes:
- This preserves existing behavior for one target per line.
- Ran `go test ./internal/runner` locally; full `go test ./...` currently fails on my machine due to unrelated client-cert tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for comma-separated values per line: input is split on commas, trimmed, and each non-empty item is processed individually for both files and standard input.

* **Bug Fixes**
  * Improved handling and error reporting when reading from standard input fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->