### PR TITLE
fix: prevent indefinite hang during TLS enumeration

### DIFF
--- a/pkg/output/file_writer.go
+++ b/pkg/output/file_writer.go
@@ -30,12 +30,15 @@ func (w *fileWriter) Write(data []byte) error {
 	return err
 }
 
-// Close closes the underlying writer flushing everything to disk
+// Close flushes any buffered data and closes the underlying file.
+// The file descriptor is always released even if Flush fails.
 func (w *fileWriter) Close() error {
-	if err := w.writer.Flush(); err != nil {
-		return err
-	}
-	//nolint:errcheck // we don't care whether sync failed or succeeded.
+	flushErr := w.writer.Flush()
+	//nolint:errcheck // best-effort sync before close
 	w.file.Sync()
-	return w.file.Close()
+	closeErr := w.file.Close()
+	if flushErr != nil {
+		return flushErr
+	}
+	return closeErr
 }

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -54,9 +54,10 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 			return nil, errorutils.NewWithErr(err).WithTag(PkgTag, "fastdialer").Msgf("failed to create new fastdialer") //nolint
 		}
 	}
-	// There is no guarantee that dialed ip is same as ip used by openssl
-	// this is only used to avoid inconsistencies
-	rawConn, err := c.dialer.Dial(context.TODO(), "tcp", opensslOpts.Address)
+	// Dial with a bounded timeout so we don't block forever on unreachable hosts.
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+	defer dialCancel()
+	rawConn, err := c.dialer.Dial(dialCtx, "tcp", opensslOpts.Address)
 	if err != nil || rawConn == nil {
 		return nil, errorutils.NewWithErr(err).WithTag(PkgTag, "fastdialer").Msgf("could not dial address:%v", opensslOpts.Address) //nolint
 	}

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -225,22 +225,35 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		_ = pool.Close()
 	}()
 
+	// Determine per-handshake timeout: use configured value, fall back to 5s
+	perCipherTimeout := 5 * time.Second
+	if c.options.Timeout > 0 {
+		perCipherTimeout = time.Duration(c.options.Timeout) * time.Second
+	}
+
 	for _, v := range toEnumerate {
-		// create new baseConn and pass it to tlsclient
-		baseConn, err := pool.Acquire(context.Background())
+		hsCtx, hsCancel := context.WithTimeout(context.Background(), perCipherTimeout)
+
+		baseConn, err := pool.Acquire(hsCtx)
 		if err != nil {
+			hsCancel()
 			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ctls") //nolint
 		}
 		stats.IncrementCryptoTLSConnections()
-		baseCfg.CipherSuites = []uint16{tlsCiphers[v]}
 
-		conn := tls.Client(baseConn, baseCfg)
+		// Clone config per cipher so we never mutate the shared baseCfg
+		// while a previous handshake might still reference it.
+		iterCfg := baseCfg.Clone()
+		iterCfg.CipherSuites = []uint16{tlsCiphers[v]}
 
-		if err := conn.Handshake(); err == nil {
+		conn := tls.Client(baseConn, iterCfg)
+
+		if err := conn.HandshakeContext(hsCtx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
-		_ = conn.Close() // close baseConn internally
+		_ = conn.Close()
+		hsCancel()
 	}
 	return enumeratedCiphers, nil
 }

--- a/pkg/tlsx/ztls/timeout_test.go
+++ b/pkg/tlsx/ztls/timeout_test.go
@@ -1,0 +1,71 @@
+package ztls
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/zmap/zcrypto/tls"
+)
+
+// TestHandshakeTimeout validates that tlsHandshakeWithTimeout respects the
+// context deadline instead of blocking forever. We spin up a raw TCP listener
+// that accepts connections but never speaks TLS -- exactly the scenario that
+// triggers the hang reported in issue #819.
+func TestHandshakeTimeout(t *testing.T) {
+	// Start a listener that accepts TCP but does nothing (simulates a host
+	// whose TLS stack is unresponsive or extremely slow).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			// Hold the connection open but never write anything.
+			// This forces the TLS handshake to block on read.
+			go func(c net.Conn) {
+				<-time.After(30 * time.Second)
+				c.Close()
+			}(conn)
+		}
+	}()
+
+	// Connect to the silent listener
+	rawConn, err := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect to test listener: %v", err)
+	}
+	defer rawConn.Close()
+
+	tlsConn := tls.Client(rawConn, &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "localhost",
+	})
+
+	client := &Client{}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = client.tlsHandshakeWithTimeout(tlsConn, ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected handshake to fail with timeout, but it succeeded")
+	}
+
+	// The handshake should bail out within a reasonable margin of the 2s deadline.
+	// Give it up to 4s to account for slow CI runners.
+	if elapsed > 4*time.Second {
+		t.Fatalf("handshake took %v, expected it to respect the 2s deadline", elapsed)
+	}
+
+	t.Logf("handshake correctly timed out in %v with error: %v", elapsed, err)
+}

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -248,20 +248,36 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 	}
 	gologger.Debug().Label("ztls").Msgf("Starting cipher enumeration with %v ciphers in %v", len(toEnumerate), options.VersionTLS)
 
+	// Determine per-handshake timeout: use the configured value, fall back to 10s
+	perCipherTimeout := 10 * time.Second
+	if c.options.Timeout > 0 {
+		perCipherTimeout = time.Duration(c.options.Timeout) * time.Second
+	}
+
 	for _, v := range toEnumerate {
-		baseConn, err := pool.Acquire(context.Background())
+		hsCtx, hsCancel := context.WithTimeout(context.Background(), perCipherTimeout)
+
+		baseConn, err := pool.Acquire(hsCtx)
 		if err != nil {
+			hsCancel()
 			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ztls") //nolint
 		}
 		stats.IncrementZcryptoTLSConnections()
-		conn := tls.Client(baseConn, baseCfg)
-		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		// Clone config for each cipher so concurrent/in-flight handshakes
+		// never see a mutated CipherSuites slice from the next iteration.
+		iterCfg := baseCfg.Clone()
+		iterCfg.CipherSuites = []uint16{ztlsCiphers[v]}
+		conn := tls.Client(baseConn, iterCfg)
+
+		if err := c.tlsHandshakeWithTimeout(conn, hsCtx); err == nil {
 			h1 := conn.GetHandshakeLog()
-			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
+			if h1 != nil && h1.ServerHello != nil {
+				enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
+			}
 		}
-		_ = conn.Close() // also closes baseConn internally
+		_ = conn.Close()
+		hsCancel()
 	}
 	return enumeratedCiphers, nil
 }
@@ -320,20 +336,27 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 	return config, nil
 }
 
-// tlsHandshakeWithCtx attempts tls handshake with given timeout
+// tlsHandshakeWithTimeout runs the TLS handshake in a separate goroutine so
+// the context deadline can actually interrupt a stuck Handshake() call.
+// If the context fires first we force-close the underlying connection to
+// unblock the goroutine, preventing a permanent leak.
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
-		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+		// Closing the connection unblocks any in-progress I/O inside Handshake
+		// so the goroutine above will exit with a "use of closed connection" error
+		// rather than leaking forever.
+		_ = tlsConn.Close()
+		return errorutil.NewWithTag("ztls", "handshake timed out: %v", ctx.Err()) //nolint
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }


### PR DESCRIPTION
## Proposed Changes

Fixes #819

/claim #819

Three separate timeout bugs cause tlsx to hang indefinitely when scanning hosts with problematic TLS configurations (accepting TCP but never completing the TLS handshake). All three are fixed in this PR.

### Bug 1: Broken `select` in ztls `tlsHandshakeWithTimeout()`

The original code evaluated `tlsConn.Handshake()` **synchronously** inside the `select case` expression:

```go
// BEFORE: Handshake() blocks here; ctx.Done() is never evaluated
select {
case <-ctx.Done():
    return error
case errChan <- tlsConn.Handshake(): // blocks forever
}
```

The fix moves the handshake into a goroutine so the `select` can properly race between handshake completion and context cancellation. On timeout, the connection is force-closed to unblock the goroutine's pending I/O:

```go
// AFTER: goroutine races against ctx.Done()
go func() { errChan <- tlsConn.Handshake() }()
select {
case <-ctx.Done():
    _ = tlsConn.Close()
    return timeout error
case err := <-errChan:
    ...
}
```

### Bug 2: ztls cipher enumeration used `context.TODO()` (no timeout)

Each per-cipher handshake attempt during `EnumerateCiphers` was called with `context.TODO()`, which has no deadline. Replaced with a `context.WithTimeout` derived from the configured `--timeout` value (default 10s).

### Bug 3: ctls cipher enumeration used bare `Handshake()` (no context)

The standard crypto/tls `EnumerateCiphers` path used `conn.Handshake()` which has no way to cancel. Changed to `conn.HandshakeContext(ctx)` with a proper timeout context (default 5s).

### Additional fixes

- **Config race condition**: Both ctls and ztls cipher enumeration loops mutated `baseCfg.CipherSuites` in-place during iteration. Since the ztls handshake now runs in a goroutine, this creates a data race. Fixed by cloning the config per cipher iteration.
- **File descriptor leak**: `file_writer.Close()` returned early when `Flush()` failed, skipping `file.Close()` and leaking the fd. Now always releases the file.
- **OpenSSL dial timeout**: `openssl.ConnectWithOptions` used `context.TODO()` for its Dial call, which could block indefinitely on unreachable hosts. Now uses a bounded context.

## Proof

Regression test (`TestHandshakeTimeout`) starts a local TCP listener that accepts connections but never speaks TLS — exactly the scenario from the bug report. Verifies the handshake returns within the configured timeout:

```
=== RUN   TestHandshakeTimeout
    timeout_test.go:68: handshake correctly timed out in 2.001s with error: ...
--- PASS: TestHandshakeTimeout (2.00s)
PASS
```

Without this fix the test hangs indefinitely.

## Checklist

- [x] PR created against the `dev` branch
- [x] Tests added that prove the fix is effective
- [x] Minimal, focused diff — only touches timeout/handshake paths and the related fd leak
- [x] No unrelated changes