### PR TITLE
fix: handle comma-separated entries in -l/--list input and stdin

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				r.processLine(text, inputs)
 			}
 		}
 	}
@@ -449,11 +449,21 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				r.processLine(text, inputs)
 			}
 		}
 	}
 	return nil
+}
+
+// processLine splits a comma-separated input line and queues each non-empty item.
+func (r *Runner) processLine(text string, inputs chan taskInput) {
+	for _, item := range strings.Split(text, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			r.processInputItem(item, inputs)
+		}
+	}
 }
 
 // resolveFQDN resolves a FQDN and returns the IP addresses

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -193,6 +193,78 @@ func Test_SelfSignedCert_processInputItem(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
 }
 
+func Test_CommaSeparatedListInput(t *testing.T) {
+	// Create a temp file with comma-separated entries on a single line
+	tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("scanme.sh,www.example.com, hackerone.com")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options := &clients.Options{
+		Ports:     []string{"443"},
+		InputList: tmpFile.Name(),
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput, 10)
+	go func() {
+		err := runner.normalizeAndQueueInputs(inputs)
+		assert.NoError(t, err)
+		close(inputs)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+
+	expected := []taskInput{
+		{host: "scanme.sh", port: "443"},
+		{host: "www.example.com", port: "443"},
+		{host: "hackerone.com", port: "443"},
+	}
+	require.ElementsMatch(t, expected, got, "comma-separated entries should be split into individual targets")
+}
+
+func Test_CommaSeparatedMultiLineListInput(t *testing.T) {
+	// Create a temp file with mixed: one entry per line and comma-separated
+	tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("scanme.sh\nwww.example.com,hackerone.com\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options := &clients.Options{
+		Ports:     []string{"443"},
+		InputList: tmpFile.Name(),
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput, 10)
+	go func() {
+		err := runner.normalizeAndQueueInputs(inputs)
+		assert.NoError(t, err)
+		close(inputs)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+
+	expected := []taskInput{
+		{host: "scanme.sh", port: "443"},
+		{host: "www.example.com", port: "443"},
+		{host: "hackerone.com", port: "443"},
+	}
+	require.ElementsMatch(t, expected, got, "mixed single-line and comma-separated entries should all be parsed")
+}
+
 func getTaskInputFromFile(filename string, ports []string) ([]taskInput, error) {
 	fileContent, err := os.ReadFile(filename)
 	if err != nil {


### PR DESCRIPTION
Fixes #859

/claim #859

## Proposed Changes

The `-u` flag handles comma-separated values via `goflags.CommaSeparatedStringSliceOptions`, but `-l`/`--list` and stdin pass entire lines directly to `processInputItem` without splitting. When a file contains comma-separated targets on a single line (e.g. `192.168.1.0/24,192.168.2.0/24,192.168.3.0/24`), the whole string is treated as one host, causing:

```
[WRN] Could not connect input 192.168.1.0/24,192.168.2.0/24,192.168.3.0/24:443
```

Added a `processLine` helper method on `Runner` that splits each scanned line by commas, trims whitespace around each item, skips empty entries, and queues each one individually. Both the file reader and stdin reader paths now use this helper, keeping the logic DRY.

Lines with a single entry (no commas) are unaffected — `strings.Split` returns a one-element slice.

## Proof

**Before** (single comma-separated line treated as one host):
```
$ echo "scanme.sh,www.example.com,hackerone.com" > targets.txt
$ tlsx -l targets.txt
[WRN] Could not connect input scanme.sh,www.example.com,hackerone.com:443
```

**After** (each entry processed individually):
```
$ echo "scanme.sh,www.example.com,hackerone.com" > targets.txt
$ tlsx -l targets.txt
scanme.sh:443
www.example.com:443
hackerone.com:443
```

**Tests:**
```
$ go test -v ./internal/runner/ -run "Test_CommaSeparated"
=== RUN   Test_CommaSeparatedListInput
--- PASS: Test_CommaSeparatedListInput (0.00s)
=== RUN   Test_CommaSeparatedMultiLineListInput
--- PASS: Test_CommaSeparatedMultiLineListInput (0.00s)
PASS
```

## Checklist

- [x] PR created against the `dev` branch
- [x] All checks passed (build, existing tests, new tests)
- [x] Tests added that prove the fix is effective
- [x] No documentation changes needed (behavioral parity with `-u`)