### PR TITLE
fix(list): split comma-separated stdin entries

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -449,7 +449,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -457,6 +457,9 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 				}
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			return errkit.Wrap(err, "could not read stdin")
+		}
 	}
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,8 +440,16 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			return errkit.Wrap(err, "could not read input file")
 		}
 	}
 	if r.hasStdin {
@@ -458,7 +466,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			return errkit.Wrap(err, "could not read stdin")
+			return errkit.Wrap(err, "could not read stdin input")
 		}
 	}
 	return nil

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,12 +440,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				for _, item := range strings.Split(text, ",") {
-					item = strings.TrimSpace(item)
-					if item != "" {
-						r.processInputItem(item, inputs)
-					}
-				}
+				r.processCommaSeparatedInputLine(text, inputs)
 			}
 		}
 		if err := scanner.Err(); err != nil {
@@ -457,12 +452,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				for _, item := range strings.Split(text, ",") {
-					item = strings.TrimSpace(item)
-					if item != "" {
-						r.processInputItem(item, inputs)
-					}
-				}
+				r.processCommaSeparatedInputLine(text, inputs)
 			}
 		}
 		if err := scanner.Err(); err != nil {
@@ -470,6 +460,15 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		}
 	}
 	return nil
+}
+
+func (r *Runner) processCommaSeparatedInputLine(text string, inputs chan taskInput) {
+	for _, item := range strings.Split(text, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			r.processInputItem(item, inputs)
+		}
+	}
 }
 
 // resolveFQDN resolves a FQDN and returns the IP addresses


### PR DESCRIPTION
Fixes #859

When reading targets from stdin, split comma-separated values (same behavior as ).

Notes:
- Trims whitespace and ignores empty segments.
- File-based  already supports this; this closes the behavior gap for stdin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input handling now supports comma-separated items on a single line from STDIN or input files; each item is processed individually.
* **Bug Fixes**
  * Improved error reporting when reading STDIN or input files, returning clearer messages for read failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->