### PR TITLE
fix: prevent indefinite hangs in TLS handshake and cipher enumeration

### DIFF
--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -226,24 +226,24 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 	}()
 
 	for _, v := range toEnumerate {
-		// create new baseConn and pass it to tlsclient
-		baseConn, err := pool.Acquire(context.Background())
+		var ctx context.Context
+		var cancel context.CancelFunc
+		if c.options.Timeout > 0 {
+			ctx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		} else {
+			ctx, cancel = context.WithCancel(context.Background())
+		}
+		baseConn, err := pool.Acquire(ctx)
 		if err != nil {
+			cancel()
 			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ctls") //nolint
 		}
 		stats.IncrementCryptoTLSConnections()
-		baseCfg.CipherSuites = []uint16{tlsCiphers[v]}
+		cfg := baseCfg.Clone()
+		cfg.CipherSuites = []uint16{tlsCiphers[v]}
+		conn := tls.Client(baseConn, cfg)
 
-		conn := tls.Client(baseConn, baseCfg)
-
-		var handshakeCtx context.Context
-		var cancel context.CancelFunc
-		if c.options.Timeout > 0 {
-			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
-		} else {
-			handshakeCtx, cancel = context.WithCancel(context.Background())
-		}
-		if err := conn.HandshakeContext(handshakeCtx); err == nil {
+		if err := conn.HandshakeContext(ctx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -236,10 +236,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 
 		conn := tls.Client(baseConn, baseCfg)
 
-		if err := conn.Handshake(); err == nil {
+		handshakeCtx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		if err := conn.HandshakeContext(handshakeCtx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
+		cancel()
 		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -236,7 +236,13 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 
 		conn := tls.Client(baseConn, baseCfg)
 
-		handshakeCtx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		var handshakeCtx context.Context
+		var cancel context.CancelFunc
+		if c.options.Timeout > 0 {
+			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		} else {
+			handshakeCtx, cancel = context.WithCancel(context.Background())
+		}
 		if err := conn.HandshakeContext(handshakeCtx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -257,10 +257,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		handshakeCtx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		if err := c.tlsHandshakeWithTimeout(conn, handshakeCtx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
+		cancel()
 		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil
@@ -323,17 +325,17 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
-
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 	select {
 	case <-ctx.Done():
+		_ = tlsConn.Close() // unblock the goroutine
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			return nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -257,7 +257,13 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		handshakeCtx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		var handshakeCtx context.Context
+		var cancel context.CancelFunc
+		if c.options.Timeout > 0 {
+			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		} else {
+			handshakeCtx, cancel = context.WithCancel(context.Background())
+		}
 		if err := c.tlsHandshakeWithTimeout(conn, handshakeCtx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -249,22 +249,24 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 	gologger.Debug().Label("ztls").Msgf("Starting cipher enumeration with %v ciphers in %v", len(toEnumerate), options.VersionTLS)
 
 	for _, v := range toEnumerate {
-		baseConn, err := pool.Acquire(context.Background())
+		var ctx context.Context
+		var cancel context.CancelFunc
+		if c.options.Timeout > 0 {
+			ctx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		} else {
+			ctx, cancel = context.WithCancel(context.Background())
+		}
+		baseConn, err := pool.Acquire(ctx)
 		if err != nil {
+			cancel()
 			return enumeratedCiphers, errorutil.NewWithErr(err).WithTag("ztls") //nolint
 		}
 		stats.IncrementZcryptoTLSConnections()
-		conn := tls.Client(baseConn, baseCfg)
-		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
+		cfg := baseCfg.Clone()
+		cfg.CipherSuites = []uint16{ztlsCiphers[v]}
+		conn := tls.Client(baseConn, cfg)
 
-		var handshakeCtx context.Context
-		var cancel context.CancelFunc
-		if c.options.Timeout > 0 {
-			handshakeCtx, cancel = context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
-		} else {
-			handshakeCtx, cancel = context.WithCancel(context.Background())
-		}
-		if err := c.tlsHandshakeWithTimeout(conn, handshakeCtx); err == nil {
+		if err := c.tlsHandshakeWithTimeout(conn, ctx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}

--- a/pkg/tlsx/ztls/ztls_test.go
+++ b/pkg/tlsx/ztls/ztls_test.go
@@ -1,13 +1,16 @@
 package ztls_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	ctls "crypto/tls"
 
@@ -105,4 +108,64 @@ func TestClientCertRequired(t *testing.T) {
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+// TestHandshakeTimeout verifies that ConnectWithOptions respects the timeout
+// when a server never completes the TLS handshake. Before the fix,
+// tlsHandshakeWithTimeout evaluated Handshake() synchronously inside the
+// select case expression, making the timeout unreachable.
+func TestHandshakeTimeout(t *testing.T) {
+	// Start a TCP server that accepts connections but never sends any data,
+	// simulating a host that hangs during the TLS handshake.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start mock server: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// deliberately never respond — simulates a hung handshake
+			defer conn.Close()
+		}
+	}()
+
+	addr := ln.Addr().String()
+	host, port, _ := net.SplitHostPort(addr)
+
+	dialer, err := fastdialer.NewDialer(fastdialer.DefaultOptions)
+	if err != nil {
+		t.Fatalf("error initializing dialer: %v", err)
+	}
+
+	timeoutSecs := 2
+	clientOpts := &clients.Options{
+		Fastdialer: dialer,
+		Timeout:    timeoutSecs,
+	}
+
+	client, err := ztls.New(clientOpts)
+	if err != nil {
+		t.Fatalf("error initializing ztls client: %v", err)
+	}
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSecs+2)*time.Second)
+	defer cancel()
+	_ = ctx // ConnectWithOptions uses client.options.Timeout internally
+
+	_, _ = client.ConnectWithOptions(host, host, port, clients.ConnectOptions{})
+	elapsed := time.Since(start)
+
+	// The call must return within roughly timeout + 1s grace period.
+	// Before the fix it would block indefinitely.
+	maxAllowed := time.Duration(timeoutSecs+1) * time.Second
+	if elapsed > maxAllowed {
+		t.Errorf("ConnectWithOptions hung: took %v, expected < %v", elapsed, maxAllowed)
+	}
+	t.Logf("ConnectWithOptions returned in %v (timeout=%ds) — OK", elapsed.Round(time.Millisecond), timeoutSecs)
 }

--- a/pkg/tlsx/ztls/ztls_test.go
+++ b/pkg/tlsx/ztls/ztls_test.go
@@ -122,14 +122,15 @@ func TestHandshakeTimeout(t *testing.T) {
 	}
 	defer ln.Close()
 
+	// Accept connections but never respond — simulates hosts that hang during TLS handshake.
+	// Connections are cleaned up when the listener is closed via defer ln.Close().
 	go func() {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
-				return
+				return // listener closed
 			}
-			// deliberately never respond — simulates a hung handshake
-			defer conn.Close()
+			_ = conn // keep open; OS reclaims on process exit
 		}
 	}()
 

--- a/pkg/tlsx/ztls/ztls_test.go
+++ b/pkg/tlsx/ztls/ztls_test.go
@@ -1,7 +1,6 @@
 package ztls_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log"
@@ -154,10 +153,6 @@ func TestHandshakeTimeout(t *testing.T) {
 	}
 
 	start := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSecs+2)*time.Second)
-	defer cancel()
-	_ = ctx // ConnectWithOptions uses client.options.Timeout internally
-
 	_, _ = client.ConnectWithOptions(host, host, port, clients.ConnectOptions{})
 	elapsed := time.Since(start)
 


### PR DESCRIPTION
Fixes #819

## What's happening

`tlsx` hangs indefinitely on certain hosts during cipher enumeration. I traced it to a few things:

**`tlsHandshakeWithTimeout` doesn't actually time out (ztls.go)**

The select runs `Handshake()` inline as the case expression, so if it blocks, the timeout case is never reached:

```go
select {
case <-ctx.Done():
    return error // dead code when Handshake blocks
case errChan <- tlsConn.Handshake():
    // blocks the entire select
}
```

Moved `Handshake()` into a goroutine so the select can actually fire on `ctx.Done()`. On timeout, `tlsConn.Close()` unblocks the goroutine.

**`context.TODO()` passed to the handshake (ztls.go)**

Even with the select fix, `EnumerateCiphers` was passing `context.TODO()` which never cancels. Replaced with a `context.WithTimeout` per cipher iteration using `options.Timeout`.

**No timeout at all in ctls path (tls.go)**

The crypto/tls `EnumerateCiphers` called `conn.Handshake()` directly — no context, no timeout. Switched to `conn.HandshakeContext(ctx)` with the same per-iteration timeout.

**`pool.Acquire` hangs on unresponsive hosts**

Both `EnumerateCiphers` paths called `pool.Acquire(context.Background())`, which can also block indefinitely if the host accepts TCP but stalls. Now uses the same timeout context for pool acquisition.

**Config mutation across loop iterations**

`baseCfg.CipherSuites` was mutated in-place each iteration. Added `baseCfg.Clone()` per iteration to avoid sharing state.

Both cipher enumeration paths include a guard for zero/negative timeout values — falls back to a cancelable context instead of failing immediately.

## Files changed

- `pkg/tlsx/ztls/ztls.go` — fix select, replace context.TODO, pool.Acquire timeout, config clone
- `pkg/tlsx/tls/tls.go` — HandshakeContext, pool.Acquire timeout, config clone
- `pkg/tlsx/ztls/ztls_test.go` — regression test with a TCP server that never responds

## Test

```
$ go test -v -run TestHandshakeTimeout ./pkg/tlsx/ztls/
=== RUN   TestHandshakeTimeout
    ztls_test.go:163: ConnectWithOptions returned in 2.001s (timeout=2s) — OK
--- PASS: TestHandshakeTimeout (2.00s)
PASS
```

The test starts a TCP listener that accepts but never sends data (simulating the hung handshake from #819). Before the fix it blocks forever. After the fix it returns within the configured timeout.

## Checklist

- [x] PR created against the correct branch (usually `dev`)
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] Tests added that prove the fix is effective
- [ ] Documentation added (if appropriate) — no docs change needed