### PR TITLE
fix: parse comma-separated entries in file (-l) and stdin input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				r.processCommaSeparatedInput(text, inputs)
 			}
 		}
 	}
@@ -449,7 +449,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				r.processCommaSeparatedInput(text, inputs)
 			}
 		}
 	}
@@ -481,6 +481,21 @@ func (r *Runner) resolveFQDN(target string) ([]string, error) {
 		hostIPs = append(hostIPs, target)
 	}
 	return hostIPs, nil
+}
+
+// processCommaSeparatedInput splits comma-separated input and processes each item individually.
+// This handles the case where file (-l) or stdin input contains multiple targets on a single line.
+func (r *Runner) processCommaSeparatedInput(input string, inputs chan taskInput) {
+	if strings.Contains(input, ",") {
+		for _, item := range strings.Split(input, ",") {
+			item = strings.TrimSpace(item)
+			if item != "" {
+				r.processInputItem(item, inputs)
+			}
+		}
+		return
+	}
+	r.processInputItem(input, inputs)
 }
 
 // processInputItem processes a single input item

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -443,6 +443,9 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 				r.processCommaSeparatedInput(text, inputs)
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			return errkit.Wrap(err, "could not read input file")
+		}
 	}
 	if r.hasStdin {
 		scanner := bufio.NewScanner(os.Stdin)
@@ -451,6 +454,9 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 			if text != "" {
 				r.processCommaSeparatedInput(text, inputs)
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			return errkit.Wrap(err, "could not read stdin")
 		}
 	}
 	return nil
@@ -486,6 +492,10 @@ func (r *Runner) resolveFQDN(target string) ([]string, error) {
 // processCommaSeparatedInput splits comma-separated input and processes each item individually.
 // This handles the case where file (-l) or stdin input contains multiple targets on a single line.
 func (r *Runner) processCommaSeparatedInput(input string, inputs chan taskInput) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return
+	}
 	if strings.Contains(input, ",") {
 		for _, item := range strings.Split(input, ",") {
 			item = strings.TrimSpace(item)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -232,8 +232,8 @@ func Test_CommaSeparatedInput_processCommaSeparatedInput(t *testing.T) {
 		},
 	}
 	go func() {
-		runner.processCommaSeparatedInput(line, inputs)
 		defer close(inputs)
+		runner.processCommaSeparatedInput(line, inputs)
 	}()
 	var got []taskInput
 	for task := range inputs {
@@ -266,8 +266,8 @@ func Test_CommaSeparatedInputWithSpaces_processCommaSeparatedInput(t *testing.T)
 		},
 	}
 	go func() {
-		runner.processCommaSeparatedInput(line, inputs)
 		defer close(inputs)
+		runner.processCommaSeparatedInput(line, inputs)
 	}()
 	var got []taskInput
 	for task := range inputs {
@@ -292,8 +292,8 @@ func Test_SingleInput_processCommaSeparatedInput(t *testing.T) {
 		},
 	}
 	go func() {
-		runner.processCommaSeparatedInput(line, inputs)
 		defer close(inputs)
+		runner.processCommaSeparatedInput(line, inputs)
 	}()
 	var got []taskInput
 	for task := range inputs {
@@ -330,8 +330,8 @@ func Test_CommaSeparatedInputMultiplePorts_processCommaSeparatedInput(t *testing
 		},
 	}
 	go func() {
-		runner.processCommaSeparatedInput(line, inputs)
 		defer close(inputs)
+		runner.processCommaSeparatedInput(line, inputs)
 	}()
 	var got []taskInput
 	for task := range inputs {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -208,6 +208,138 @@ func getTaskInputFromFile(filename string, ports []string) ([]taskInput, error) 
 	return ret, nil
 }
 
+// Comma-separated input from file (-l) or stdin
+func Test_CommaSeparatedInput_processCommaSeparatedInput(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	line := "www.example.com,scanme.sh,test.com"
+	expected := []taskInput{
+		{
+			host: "www.example.com",
+			port: "443",
+		},
+		{
+			host: "scanme.sh",
+			port: "443",
+		},
+		{
+			host: "test.com",
+			port: "443",
+		},
+	}
+	go func() {
+		runner.processCommaSeparatedInput(line, inputs)
+		defer close(inputs)
+	}()
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
+}
+
+// Comma-separated input with spaces around commas
+func Test_CommaSeparatedInputWithSpaces_processCommaSeparatedInput(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	line := "www.example.com , scanme.sh , test.com"
+	expected := []taskInput{
+		{
+			host: "www.example.com",
+			port: "443",
+		},
+		{
+			host: "scanme.sh",
+			port: "443",
+		},
+		{
+			host: "test.com",
+			port: "443",
+		},
+	}
+	go func() {
+		runner.processCommaSeparatedInput(line, inputs)
+		defer close(inputs)
+	}()
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
+}
+
+// Single input (no commas) still works through processCommaSeparatedInput
+func Test_SingleInput_processCommaSeparatedInput(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443"},
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	line := "www.example.com"
+	expected := []taskInput{
+		{
+			host: "www.example.com",
+			port: "443",
+		},
+	}
+	go func() {
+		runner.processCommaSeparatedInput(line, inputs)
+		defer close(inputs)
+	}()
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
+}
+
+// Comma-separated with multiple ports
+func Test_CommaSeparatedInputMultiplePorts_processCommaSeparatedInput(t *testing.T) {
+	options := &clients.Options{
+		Ports: []string{"443", "8443"},
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	line := "www.example.com,scanme.sh"
+	expected := []taskInput{
+		{
+			host: "www.example.com",
+			port: "443",
+		},
+		{
+			host: "www.example.com",
+			port: "8443",
+		},
+		{
+			host: "scanme.sh",
+			port: "443",
+		},
+		{
+			host: "scanme.sh",
+			port: "8443",
+		},
+	}
+	go func() {
+		runner.processCommaSeparatedInput(line, inputs)
+		defer close(inputs)
+	}()
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+	require.ElementsMatch(t, expected, got, "could not get correct taskInputs")
+}
+
 func Test_CTLogsModeValidation(t *testing.T) {
 	// Test that CT logs mode and input mode cannot be used together
 	// This validation is now done in the main package, so this test should be removed


### PR DESCRIPTION
## Summary

Fixes #859

The `-u` flag uses `CommaSeparatedStringSliceOptions` from goflags which auto-splits comma-separated values, but file (`-l`) and stdin input paths read lines via `bufio.Scanner` and pass them directly to `processInputItem()` without splitting on commas. This means a file like:

```
scanme.sh,example.com,test.com
```

gets treated as a single host `scanme.sh,example.com,test.com` instead of three separate hosts.

### Changes

- Added `processCommaSeparatedInput()` method that splits comma-delimited input before calling `processInputItem()` for each entry
- Applied the fix to both file (`-l`) and stdin input paths in `normalizeAndQueueInputs()`
- Handles whitespace around commas (e.g., `foo.com , bar.com`)
- Falls through to `processInputItem()` directly when no comma is present (zero overhead for non-comma input)

### Before

```
$ echo "scanme.sh,example.com" | tlsx
# → tries to connect to "scanme.sh,example.com" as a single host (fails)
```

### After

```
$ echo "scanme.sh,example.com" | tlsx
# → scans scanme.sh and example.com separately
```

Same fix applies to `-l` file input.

## Test plan

- [x] Added 4 new unit tests covering:
  - Basic comma-separated splitting (a,b,c → 3 hosts)
  - Spaces around commas (a , b , c → 3 hosts, trimmed)
  - Single input passthrough (no comma, no behavior change)
  - Comma-separated with multiple ports (cross-product)
- [x] All existing tests pass
- [x] go build -v ./... clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled parsing of comma-separated targets in input lines, allowing multiple hosts per line with robust whitespace handling and improved handling of read errors from input sources.

* **Tests**
  * Added unit tests covering comma-separated input parsing across formatting scenarios (multiple hosts, surrounding spaces, single host, multiple ports).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->