### PR TITLE
fix: support comma-separated prefixes in -l option like -u

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,14 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Split comma-separated values like -u option does
+				parts := strings.Split(text, ",")
+				for _, part := range parts {
+					trimmed := strings.TrimSpace(part)
+					if trimmed != "" {
+						r.processInputItem(trimmed, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input processing to correctly handle comma-separated values as individual items rather than treating the entire line as a single input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->