### PR TITLE
fix: parse comma-separated list/stdin input targets

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,7 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				r.processCommaSeparatedInput(text, inputs)
 			}
 		}
 	}
@@ -449,11 +449,21 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				r.processCommaSeparatedInput(text, inputs)
 			}
 		}
 	}
 	return nil
+}
+
+func (r *Runner) processCommaSeparatedInput(text string, inputs chan taskInput) {
+	for _, part := range strings.Split(text, ",") {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		r.processInputItem(trimmed, inputs)
+	}
 }
 
 // resolveFQDN resolves a FQDN and returns the IP addresses

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -429,3 +429,25 @@ func Test_CTLogsModeOutputOptions(t *testing.T) {
 		})
 	}
 }
+
+func Test_ProcessCommaSeparatedInput(t *testing.T) {
+	options := &clients.Options{Ports: []string{"443"}}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput)
+	go func() {
+		runner.processCommaSeparatedInput("example.com, one.one.one.one ,", inputs)
+		close(inputs)
+	}()
+
+	var got []taskInput
+	for task := range inputs {
+		got = append(got, task)
+	}
+
+	expected := []taskInput{
+		{host: "example.com", port: "443"},
+		{host: "one.one.one.one", port: "443"},
+	}
+	require.ElementsMatch(t, expected, got)
+}


### PR DESCRIPTION
## Proposed Changes

Fix input normalization so `-l/--list` file input and stdin handle comma-separated targets on a single line the same way as `-u`.

- Added `processCommaSeparatedInput` to split by comma, trim whitespace, and skip empty tokens.
- Applied this path to both list file scanner and stdin scanner.
- Added regression test `Test_ProcessCommaSeparatedInput`.

## Proof

### Repro behavior (before)
A single list line like:

```text
192.168.1.0/24,192.168.2.0/24,192.168.3.0/24
```

was treated as one host entry and failed with:

```text
no address found for host
```

### Test evidence (after)

```bash
go test ./internal/runner -run "ProcessCommaSeparatedInput|InputDomain|InputCIDR" -count=1
ok  github.com/projectdiscovery/tlsx/internal/runner
```

The new regression test verifies comma-separated entries are split into independent targets.

/claim #859
