### PR TITLE
feat: add key_exchange field for negotiated TLS key exchange group

### DIFF
--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -206,6 +206,8 @@ type Response struct {
 	Version string `json:"tls_version,omitempty"`
 	// Cipher is the cipher for the tls request
 	Cipher string `json:"cipher,omitempty"`
+	// KeyExchange is the negotiated key exchange/curve
+	KeyExchange string `json:"key_exchange,omitempty"`
 	// CertificateResponse is the leaf certificate embedded in json
 	*CertificateResponse `json:",inline"`
 	// TLSConnection is the client used for TLS connection

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"time"
@@ -142,6 +143,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	}
 	tlsVersion := versionToTLSVersionString[connectionState.Version]
 	tlsCipher := tls.CipherSuiteName(connectionState.CipherSuite)
+	tlsKeyExchange := curveIDToString(connectionState.CurveID)
 
 	leafCertificate := connectionState.PeerCertificates[0]
 	certificateChain := connectionState.PeerCertificates[1:]
@@ -160,6 +162,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		Port:                port,
 		Version:             tlsVersion,
 		Cipher:              tlsCipher,
+		KeyExchange:         tlsKeyExchange,
 		TLSConnection:       "ctls",
 		CertificateResponse: clients.Convertx509toResponse(c.options, hostname, leafCertificate, c.options.Cert),
 		ServerName:          config.ServerName,
@@ -297,4 +300,30 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 		return nil, errorutil.NewWithTag("ctls", "cipher enum with version %v not implemented", options.VersionTLS) //nolint
 	}
 	return config, nil
+}
+
+// curveIDToString converts CurveID to a human-readable string
+func curveIDToString(curveID tls.CurveID) string {
+	// Standard curve IDs from crypto/tls
+	switch curveID {
+	case 23:
+		return "CurveP256"
+	case 24:
+		return "CurveP384"
+	case 25:
+		return "CurveP521"
+	case 29:
+		return "X25519"
+	case 4588:
+		return "X25519MLKEM768"
+	case 0:
+		return "" // No curve negotiated
+	default:
+		// Try using the built-in String() method if available
+		// Otherwise return the numeric form
+		if curveID > 0 {
+			return fmt.Sprintf("CurveID(%d)", curveID)
+		}
+		return ""
+	}
 }


### PR DESCRIPTION
Closes #935.

## Summary

`crypto/tls` `ConnectionState.CurveID` has been populated after the handshake since Go 1.24. This PR exposes it in tlsx output as `key_exchange` (JSON) and via a new `-ke` / `--key-exchange` CLI flag.

In TLS 1.3, the cipher suite name no longer encodes the key exchange mechanism — it is negotiated separately. Without this field, there is no way to distinguish a post-quantum secured connection from a classical one when scanning at scale.

## Changes

- `pkg/tlsx/clients/clients.go` — add `KeyExchange bool` option and `KeyExchange string` to `Response`
- `pkg/tlsx/tls/tls.go` — read `connectionState.CurveID.String()` and populate `response.KeyExchange`
- `cmd/tlsx/main.go` — add `-ke` / `--key-exchange` flag
- `pkg/output/output.go` — display in text output (cyan, alongside cipher)
- `internal/runner/banner.go` — include `KeyExchange` in `probeSpecified`

## Usage

```bash
# Text output
tlsx -host cloudflare.com,github.com -ke -cipher -tls-version
# cloudflare.com [tls13] [TLS_AES_128_GCM_SHA256] [X25519MLKEM768]
# github.com     [tls13] [TLS_AES_128_GCM_SHA256] [X25519]

# JSON output (always included when field is non-empty)
tlsx -host cloudflare.com -json | jq .key_exchange
# "X25519MLKEM768"
```

## Notes

- Only populated for the `ctls` (standard `crypto/tls`) client; ztls does not expose `CurveID` in its `ServerHello` struct
- `CurveID.String()` in Go 1.24+ handles all known groups including `X25519MLKEM768` (CurveID 4588)
- Field is omitted from JSON when empty (TLS < 1.3 or ztls path)
- Pre-existing `TestClientCertRequired` failure in tls and ztls packages is unrelated to this PR (TLS 1.0 handshake rejection on Go 1.25)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reporting of the negotiated key exchange group in TLS handshake information, enabling visibility into the cryptographic parameters used during secure connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->