### PR TITLE
Fix #819: sanitize CN to prevent hang

### DIFF
--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -154,8 +154,8 @@ func IsClientCertRequiredError(err error) bool {
 	return false
 }
 func sanitizeCN(s string) string {
-	if len(s) > 256 {
-		s = s[:256]
+	if len(runes) > 256 {
+		runes = runes[:256]
 	}
 	return strings.ToValidUTF8(s, "")
 }

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -14,12 +14,12 @@ import (
 	iputil "github.com/projectdiscovery/utils/ip"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 )
-
 func Convertx509toResponse(options *Options, hostname string, cert *x509.Certificate, showcert bool) *CertificateResponse {
 subjectCN := sanitizeCN(cert.Subject.CommonName)
 	issuerCN := sanitizeCN(cert.Issuer.CommonName)
-	
-    domainNames := []string{cert.Subject.CommonName}
+
+
+	domainNames := []string{subjectCN}
 	domainNames = append(domainNames, cert.DNSNames...)
 	response := &CertificateResponse{
 		SubjectAN:    cert.DNSNames,
@@ -31,9 +31,9 @@ subjectCN := sanitizeCN(cert.Subject.CommonName)
 		MisMatched:   IsMisMatchedCert(hostname, domainNames),
 		Revoked:      IsTLSRevoked(options, cert),
 		WildCardCert: IsWildCardCert(domainNames),
-		IssuerCN:     sanitizeCN(cert.Issuer.CommonName),
+		IssuerCN:     issuerCN,
 		IssuerOrg:    cert.Issuer.Organization,
-		SubjectCN:    sanitizeCN(cert.Subject.CommonName),
+		SubjectCN:    subjectCN,
 		SubjectOrg:   cert.Subject.Organization,
 		FingerprintHash: CertificateResponseFingerprintHash{
 			MD5:    MD5Fingerprint(cert.Raw),
@@ -157,8 +157,8 @@ func IsClientCertRequiredError(err error) bool {
 	return false
 }
 func sanitizeCN(s string) string {
-	var b strings.builder
-	b.Grow(256*utf8.UTFMax)
+	var b strings.Builder
+	b.Grow(256 * utf8.UTFMax)
 	count := 0
 	for len(s)>0 && count<256 {
 		r, size := utf8.DecodeRuneInString(s)

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -9,14 +9,17 @@ import (
 	"net"
 	"strings"
 	"time"
-
+    "unicode/utf8"
 	"github.com/projectdiscovery/utils/errkit"
 	iputil "github.com/projectdiscovery/utils/ip"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 )
 
 func Convertx509toResponse(options *Options, hostname string, cert *x509.Certificate, showcert bool) *CertificateResponse {
-	domainNames := []string{cert.Subject.CommonName}
+subjectCN := sanitizeCN(cert.Subject.CommonName)
+	issuerCN := sanitizeCN(cert.Issuer.CommonName)
+	
+    domainNames := []string{cert.Subject.CommonName}
 	domainNames = append(domainNames, cert.DNSNames...)
 	response := &CertificateResponse{
 		SubjectAN:    cert.DNSNames,
@@ -154,9 +157,19 @@ func IsClientCertRequiredError(err error) bool {
 	return false
 }
 func sanitizeCN(s string) string {
-	runes := []rune(s)
-	if len(runes) > 256 {
-		runes = runes[:256]
+	var b strings.builder
+	b.Grow(256*utf8.UTFMax)
+	count := 0
+	for len(s)>0 && count<256 {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			s = s[1:]
+			continue
+		}
+		b.WriteRune(r)
+		s = s[size:]
+		count++
 	}
-	return strings.ToValidUTF8(string(runes), "")
+
+	return b.String()
 }

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -154,8 +154,9 @@ func IsClientCertRequiredError(err error) bool {
 	return false
 }
 func sanitizeCN(s string) string {
+	runes := []rune(s)
 	if len(runes) > 256 {
 		runes = runes[:256]
 	}
-	return strings.ToValidUTF8(s, "")
+	return strings.ToValidUTF8(string(runes), "")
 }

--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -28,9 +28,9 @@ func Convertx509toResponse(options *Options, hostname string, cert *x509.Certifi
 		MisMatched:   IsMisMatchedCert(hostname, domainNames),
 		Revoked:      IsTLSRevoked(options, cert),
 		WildCardCert: IsWildCardCert(domainNames),
-		IssuerCN:     cert.Issuer.CommonName,
+		IssuerCN:     sanitizeCN(cert.Issuer.CommonName),
 		IssuerOrg:    cert.Issuer.Organization,
-		SubjectCN:    cert.Subject.CommonName,
+		SubjectCN:    sanitizeCN(cert.Subject.CommonName),
 		SubjectOrg:   cert.Subject.Organization,
 		FingerprintHash: CertificateResponseFingerprintHash{
 			MD5:    MD5Fingerprint(cert.Raw),
@@ -152,4 +152,10 @@ func IsClientCertRequiredError(err error) bool {
 		}
 	}
 	return false
+}
+func sanitizeCN(s string) string {
+	if len(s) > 256 {
+		s = s[:256]
+	}
+	return strings.ToValidUTF8(s, "")
 }


### PR DESCRIPTION
This PR fixes the indefinite hang issue (#819) by sanitizing SubjectCN and IssuerCN length and encoding. /claim #819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate issuer and subject common names are now sanitized: truncated to 256 characters and normalized to valid UTF-8 to prevent display or processing issues.
  * Responses now use the sanitized subject and issuer names and include those sanitized values in the response path.
  * Domain name handling and client-certificate error behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->