### PR TITLE
fix: handle comma-separated entries in -l/-list and stdin input

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -439,8 +439,11 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			text := scanner.Text()
-			if text != "" {
-				r.processInputItem(text, inputs)
+			for _, item := range strings.Split(text, ",") {
+				item = strings.TrimSpace(item)
+				if item != "" {
+					r.processInputItem(item, inputs)
+				}
 			}
 		}
 	}
@@ -448,8 +451,11 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			text := scanner.Text()
-			if text != "" {
-				r.processInputItem(text, inputs)
+			for _, item := range strings.Split(text, ",") {
+				item = strings.TrimSpace(item)
+				if item != "" {
+					r.processInputItem(item, inputs)
+				}
 			}
 		}
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -446,6 +446,9 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 				}
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			return errkit.Wrap(err, "could not read input file")
+		}
 	}
 	if r.hasStdin {
 		scanner := bufio.NewScanner(os.Stdin)
@@ -457,6 +460,9 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 					r.processInputItem(item, inputs)
 				}
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			return errkit.Wrap(err, "could not read stdin input")
 		}
 	}
 	return nil

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -380,6 +380,77 @@ func Test_CTLogsModeWithAllProbes(t *testing.T) {
 	}
 }
 
+func Test_CommaSeparatedFileInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "comma-separated entries",
+			content:  "scanme.sh,example.com",
+			expected: []string{"scanme.sh", "example.com"},
+		},
+		{
+			name:     "comma-separated with spaces",
+			content:  "host1.com , host2.com , host3.com",
+			expected: []string{"host1.com", "host2.com", "host3.com"},
+		},
+		{
+			name:     "single entry no comma",
+			content:  "scanme.sh",
+			expected: []string{"scanme.sh"},
+		},
+		{
+			name:     "trailing comma filtered",
+			content:  "a.com,b.com,",
+			expected: []string{"a.com", "b.com"},
+		},
+		{
+			name:     "host with port",
+			content:  "example.com:8443,scanme.sh:443",
+			expected: []string{"example.com", "scanme.sh"},
+		},
+		{
+			name:     "multiple lines with commas",
+			content:  "a.com,b.com\nc.com,d.com",
+			expected: []string{"a.com", "b.com", "c.com", "d.com"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", "tlsx-test-*.txt")
+			require.NoError(t, err)
+			defer os.Remove(tmpFile.Name())
+
+			_, err = tmpFile.WriteString(tc.content)
+			require.NoError(t, err)
+			require.NoError(t, tmpFile.Close())
+
+			options := &clients.Options{
+				Ports:     []string{"443"},
+				InputList: tmpFile.Name(),
+			}
+			runner := &Runner{options: options}
+
+			inputs := make(chan taskInput, 100)
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- runner.normalizeAndQueueInputs(inputs)
+				close(inputs)
+			}()
+
+			var hosts []string
+			for task := range inputs {
+				hosts = append(hosts, task.host)
+			}
+			require.NoError(t, <-errCh)
+			require.ElementsMatch(t, tc.expected, hosts)
+		})
+	}
+}
+
 func Test_CTLogsModeOutputOptions(t *testing.T) {
 	// Test that CT logs mode works with various output options
 	testCases := []struct {


### PR DESCRIPTION
## Description

Fixes #859 — `-l`/`-list` and stdin input now correctly handle comma-separated targets on a single line, matching the existing `-u` flag behavior.

### Problem

When using `-u host1,host2,host3`, targets are correctly split by comma via `CommaSeparatedStringSliceOptions` in goflags. However, when using `-l file.txt` where the file contains comma-separated targets on a single line, the entire line is treated as one target, causing connection failures.

### Root Cause

In `normalizeAndQueueInputs`, the bufio scanner reads each line and passes it directly to `processInputItem` without splitting on commas. The `-u` flag gets comma-splitting for free from goflags, but file/stdin inputs bypass that.

### Fix

Split each scanned line on commas (with trimming) before passing to `processInputItem`, in both the file-input and stdin-input code paths.

### Changes

- `internal/runner/runner.go`: Added `strings.Split(text, ",")` loop with `strings.TrimSpace` in both the `-l` file scanner and the stdin scanner blocks of `normalizeAndQueueInputs`.

### Testing

- Build passes (`go build -buildvcs=false ./cmd/tlsx/`)
- No new dependencies added (`strings` was already imported)
- Comma splitting is safe for all valid target types (IP, CIDR, FQDN, ASN) as none contain commas

/claim #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input processing now treats comma-separated entries on a line as individual items for both file and stdin input.

* **Bug Fixes**
  * Improved error handling with clearer messages when reading input from files or stdin.

* **Tests**
  * Added comprehensive tests validating comma-separated input parsing and various formatting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->