### PR TITLE
fix: indefinite hangs during TLS handshake and cipher enumeration

### DIFF
--- a/internal/pdcp/writer.go
+++ b/internal/pdcp/writer.go
@@ -52,6 +52,7 @@ type UploadWriter struct {
 	assetGroupID   string
 	assetGroupName string
 	counter        atomic.Int32
+	droppedCounter atomic.Int32
 	closed         atomic.Bool
 	TeamID         string
 }
@@ -94,6 +95,7 @@ func (u *UploadWriter) GetWriterCallback() func(*clients.Response) {
 		select {
 		case u.data <- resp:
 		default:
+			u.droppedCounter.Add(1)
 			gologger.Warning().Msgf("PDCP upload buffer full, skipping result")
 		}
 	}
@@ -128,6 +130,9 @@ func (u *UploadWriter) autoCommit(ctx context.Context) {
 			gologger.Verbose().Msgf("UI dashboard setup skipped, no results found to upload")
 		} else {
 			gologger.Info().Msgf("Found %v results, View found results in dashboard : %v", u.counter.Load(), getAssetsDashBoardURL(u.assetGroupID, u.TeamID))
+		}
+		if dropped := u.droppedCounter.Load(); dropped > 0 {
+			gologger.Warning().Msgf("Dropped %v results due to upload buffer overflow", dropped)
 		}
 	}()
 	// temporary buffer to store the results

--- a/internal/pdcp/writer.go
+++ b/internal/pdcp/writer.go
@@ -65,7 +65,7 @@ func NewUploadWriterCallback(ctx context.Context, creds *pdcpauth.PDCPCredential
 	u := &UploadWriter{
 		creds:  creds,
 		done:   make(chan struct{}, 1),
-		data:   make(chan *clients.Response, 8), // default buffer size
+		data:   make(chan *clients.Response, 1000), // increased buffer size
 		TeamID: "",
 	}
 	var err error
@@ -91,7 +91,11 @@ func NewUploadWriterCallback(ctx context.Context, creds *pdcpauth.PDCPCredential
 // GetWriterCallback returns the writer callback
 func (u *UploadWriter) GetWriterCallback() func(*clients.Response) {
 	return func(resp *clients.Response) {
-		u.data <- resp
+		select {
+		case u.data <- resp:
+		default:
+			gologger.Warning().Msgf("PDCP upload buffer full, skipping result")
+		}
 	}
 }
 

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -236,10 +236,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 
 		conn := tls.Client(baseConn, baseCfg)
 
-		if err := conn.Handshake(); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		if err := conn.HandshakeContext(ctx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
+		cancel()
 		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil

--- a/pkg/tlsx/tls/tls.go
+++ b/pkg/tlsx/tls/tls.go
@@ -236,12 +236,18 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 
 		conn := tls.Client(baseConn, baseCfg)
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if c.options.Timeout != 0 {
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(c.options.Timeout)*time.Second)
+		}
 		if err := conn.HandshakeContext(ctx); err == nil {
 			ciphersuite := conn.ConnectionState().CipherSuite
 			enumeratedCiphers = append(enumeratedCiphers, tls.CipherSuiteName(ciphersuite))
 		}
-		cancel()
+		if cancel != nil {
+			cancel()
+		}
 		_ = conn.Close() // close baseConn internally
 	}
 	return enumeratedCiphers, nil

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -140,7 +140,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 	// new tls connection
 	tlsConn := tls.Client(conn, config)
-	err = c.tlsHandshakeWithTimeout(tlsConn, ctx)
+	err = c.tlsHandshakeWithTimeout(ctx, tlsConn)
 	if err != nil {
 		if clients.IsClientCertRequiredError(err) {
 			clientCertRequired = true
@@ -262,7 +262,7 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		if c.options.Timeout != 0 {
 			ctx, cancel = context.WithTimeout(ctx, time.Duration(c.options.Timeout)*time.Second)
 		}
-		if err := c.tlsHandshakeWithTimeout(conn, ctx); err == nil {
+		if err := c.tlsHandshakeWithTimeout(ctx, conn); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
@@ -329,7 +329,7 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 }
 
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
-func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
+func (c *Client) tlsHandshakeWithTimeout(ctx context.Context, tlsConn *tls.Conn) error {
 	errChan := make(chan error, 1)
 
 	go func() {

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -257,12 +257,18 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if c.options.Timeout != 0 {
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(c.options.Timeout)*time.Second)
+		}
 		if err := c.tlsHandshakeWithTimeout(conn, ctx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
-		cancel()
+		if cancel != nil {
+			cancel()
+		}
 		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -257,10 +257,12 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+		if err := c.tlsHandshakeWithTimeout(conn, ctx); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
+		cancel()
 		_ = conn.Close() // also closes baseConn internally
 	}
 	return enumeratedCiphers, nil
@@ -323,17 +325,18 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			err = nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }


### PR DESCRIPTION
This PR fixes multiple indefinite hangs in tlsx:
1. Fixed a race condition/deadlock in ztls.tlsHandshakeWithTimeout where the select statement would block during function call evaluation, making the context timeout ineffective.
2. Added missing context timeouts to EnumerateCiphers in both ztls and ctls (stdlib) clients.
3. Increased the buffer size and implemented non-blocking sends for the PDCP UploadWriter to prevent worker goroutines from stalling on slow cloud uploads.

These fixes resolve issue #819 where tlsx hangs indefinitely after processing a large number of targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased internal buffering and made data sends non-blocking; dropped sends are counted and logged, with a shutdown warning if drops occurred.
  * Improved TLS operations to use per-call timeouts and cancellable contexts for handshakes, with consolidated error handling and clearer failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->