### PR TITLE
fix: support comma-separated values in -l file and stdin input (#859)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +454,12 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					item = strings.TrimSpace(item)
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -429,3 +429,56 @@ func Test_CTLogsModeOutputOptions(t *testing.T) {
 		})
 	}
 }
+
+// Test that comma-separated values in -l file are split correctly (#859)
+func Test_CommaSeparatedInputFile_normalizeAndQueueInputs(t *testing.T) {
+	// Create a temp file with comma-separated hosts on a single line
+	tmpFile, err := os.CreateTemp(t.TempDir(), "hosts-*.txt")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString("example.com,example.org,example.net\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options := &clients.Options{
+		Ports:     []string{"443"},
+		InputList: tmpFile.Name(),
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput, 10)
+	err = runner.normalizeAndQueueInputs(inputs)
+	require.NoError(t, err)
+	close(inputs)
+
+	var got []string
+	for task := range inputs {
+		got = append(got, task.host)
+	}
+	require.ElementsMatch(t, []string{"example.com", "example.org", "example.net"}, got)
+}
+
+// Test that a single value per line still works (#859 regression)
+func Test_SingleInputPerLine_normalizeAndQueueInputs(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "hosts-*.txt")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString("example.com\nexample.org\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	options := &clients.Options{
+		Ports:     []string{"443"},
+		InputList: tmpFile.Name(),
+	}
+	runner := &Runner{options: options}
+
+	inputs := make(chan taskInput, 10)
+	err = runner.normalizeAndQueueInputs(inputs)
+	require.NoError(t, err)
+	close(inputs)
+
+	var got []string
+	for task := range inputs {
+		got = append(got, task.host)
+	}
+	require.ElementsMatch(t, []string{"example.com", "example.org"}, got)
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #859

/claim #859

## Description

When using `-l` / `-list` with a file containing comma-separated entries on a single line, each entry is now correctly split and processed individually — matching the existing behavior of `-u`.

## Changes

- **internal/runner/runner.go**: Split each line on commas when reading from file (`-l`) and stdin, trimming whitespace and skipping empty entries
- **internal/runner/runner_test.go**: Added two test cases:
  - Comma-separated values in file are correctly split into individual hosts
  - Single value per line still works (regression test)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Input items can now be provided as comma-separated values on a single line, in addition to the existing one-item-per-line format.

* **Tests**
  * Added test coverage for comma-separated input parsing and single-item-per-line input processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->