### PR TITLE
fix: support comma-separated inputs in list file (-l option)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,11 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				for _, item := range strings.Split(text, ",") {
+					if item != "" {
+						r.processInputItem(item, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #859

The `-u` option correctly handles comma-separated targets (e.g., `./tlsx -u 192.168.1.0/24,192.168.2.0/24`) via `CommaSeparatedStringSliceOptions`, but the `-l` option treated each line as a single target.

## Changes

- Modified `internal/runner/runner.go` to split each line by comma when reading from the input list file, matching the behavior of the `-u` option.

## Testing

- Build passes: `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced input file processing to support comma-separated values. Users can now specify multiple input items on a single line by separating them with commas, providing improved flexibility in structuring input files and reducing the need for multiple lines when handling related inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->