### PR TITLE
[BOUNTY #819] Fix indefinite hanging on certain hosts

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -396,9 +396,26 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 			gologger.Info().Msgf("Processing input %s:%s", task.host, task.port)
 		}
 
-		response, err := tlsxService.ConnectWithOptions(task.host, task.ip, task.port, clients.ConnectOptions{SNI: task.sni})
+		var response *clients.Response
+		var err error
+		// Use a per-connection timeout to prevent indefinite hangs
+		connTimeout := time.Duration(r.options.Timeout) * time.Second
+		if connTimeout <= 0 {
+			connTimeout = 10 * time.Second
+		}
+		// For enum modes that make multiple connections, allow more time
+		if r.options.TlsVersionsEnum || r.options.TlsCiphersEnum {
+			connTimeout *= 3
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), connTimeout)
+		response, err = r.connectWithTimeout(ctx, tlsxService, task.host, task.ip, task.port, task.sni)
+		cancel()
 		if err != nil {
-			gologger.Warning().Msgf("Could not connect input %s: %s", task.Address(), err)
+			if ctx.Err() == context.DeadlineExceeded {
+				gologger.Warning().Msgf("Could not connect input %s: timeout after %v", task.Address(), connTimeout)
+			} else {
+				gologger.Warning().Msgf("Could not connect input %s: %s", task.Address(), err)
+			}
 		}
 
 		if response == nil {
@@ -415,6 +432,25 @@ func (r *Runner) processInputElementWorker(inputs chan taskInput, wg *sync.WaitG
 			callback := r.pdcpWriter.GetWriterCallback()
 			callback(response)
 		}
+	}
+}
+
+// connectWithTimeout wraps ConnectWithOptions with a context timeout to prevent indefinite hangs
+func (r *Runner) connectWithTimeout(ctx context.Context, tlsxService *tlsx.Service, host, ip, port, sni string) (*clients.Response, error) {
+	type result struct {
+		response *clients.Response
+		err      error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		resp, err := tlsxService.ConnectWithOptions(host, ip, port, clients.ConnectOptions{SNI: sni})
+		ch <- result{resp, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.response, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 

--- a/pkg/tlsx/openssl/openssl.go
+++ b/pkg/tlsx/openssl/openssl.go
@@ -46,6 +46,8 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	if c.options.Timeout < 3 {
 		c.options.Timeout = 3
 	}
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Duration(c.options.Timeout)*time.Second)
+	defer dialCancel()
 	// validate dialer before using
 	if c.dialer == nil {
 		var err error
@@ -56,7 +58,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 	}
 	// There is no guarantee that dialed ip is same as ip used by openssl
 	// this is only used to avoid inconsistencies
-	rawConn, err := c.dialer.Dial(context.TODO(), "tcp", opensslOpts.Address)
+	rawConn, err := c.dialer.Dial(dialCtx, "tcp", opensslOpts.Address)
 	if err != nil || rawConn == nil {
 		return nil, errorutils.NewWithErr(err).WithTag(PkgTag, "fastdialer").Msgf("could not dial address:%v", opensslOpts.Address) //nolint
 	}


### PR DESCRIPTION
## Summary

Fixes #819 — tlsx hangs indefinitely during long-running scans (e.g., 30k targets over ~18 hours).

## Root Cause

- The `processInputElementWorker` in `internal/runner/runner.go` called `ConnectWithOptions` without any overall timeout safety net. If a connection stalled (e.g., TCP accepted but TLS handshake never completes), the goroutine would block forever.
- The openssl client in `pkg/tlsx/openssl/openssl.go` dialed with `context.TODO()`, meaning no timeout was applied to the TCP connection phase.
- This manifested as hangs after thousands of successful connections, with output truncated mid-JSON line.

## Changes

1. **`internal/runner/runner.go`**: Added `connectWithTimeout()` wrapper that enforces a per-connection timeout via `context.WithTimeout`. For cipher/version enumeration modes, the timeout is tripled since multiple connections are made.
2. **`pkg/tlsx/openssl/openssl.go`**: Replaced `context.TODO()` with a timeout context derived from `options.Timeout` for the dial call.

## Testing

- `go build ./...` passes
- No conflicts with existing PR #963

Closes #819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connection timeout handling to prevent indefinite hangs during connection attempts
  * Enhanced error reporting to distinguish connection timeout failures from other error types with clearer timeout-specific messaging
  * Optimized timeout behavior for TLS enumeration operations with dynamic timeout adjustment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->