### PR TITLE
fix(ztls): move handshake to goroutine to prevent indefinite hang

### DIFF
--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -320,20 +320,22 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 	return config, nil
 }
 
-// tlsHandshakeWithCtx attempts tls handshake with given timeout
+// tlsHandshakeWithTimeout attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
-		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+		return errorutil.NewWithTag("ztls", "timeout while attempting handshake").Wrap(ctx.Err()) //nolint
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			err = nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }
+

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -140,7 +140,7 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 
 	// new tls connection
 	tlsConn := tls.Client(conn, config)
-	err = c.tlsHandshakeWithTimeout(tlsConn, ctx)
+	err = c.tlsHandshakeWithTimeout(ctx, tlsConn)
 	if err != nil {
 		if clients.IsClientCertRequiredError(err) {
 			clientCertRequired = true
@@ -257,7 +257,7 @@ func (c *Client) EnumerateCiphers(hostname, ip, port string, options clients.Con
 		conn := tls.Client(baseConn, baseCfg)
 		baseCfg.CipherSuites = []uint16{ztlsCiphers[v]}
 
-		if err := c.tlsHandshakeWithTimeout(conn, context.TODO()); err == nil {
+		if err := c.tlsHandshakeWithTimeout(context.TODO(), conn); err == nil {
 			h1 := conn.GetHandshakeLog()
 			enumeratedCiphers = append(enumeratedCiphers, h1.ServerHello.CipherSuite.String())
 		}
@@ -321,7 +321,7 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 }
 
 // tlsHandshakeWithTimeout attempts tls handshake with given timeout
-func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
+func (c *Client) tlsHandshakeWithTimeout(ctx context.Context, tlsConn *tls.Conn) error {
 	errChan := make(chan error, 1)
 
 	go func() {


### PR DESCRIPTION
This PR fixes an indefinite hang in the ztls client.

**Root Cause:** The  method was being called synchronously within a  case. In Go, case expressions are evaluated before the select blocks, meaning the handshake was executed on the main goroutine, effectively bypassing the context timeout if the network connection hung.

**Fix:** Moved the  call to a separate goroutine and used the  block to wait for either the result or the context cancellation.

**Payout Wallet (EVM):** `0x0c67cbE9e30c66267975eE2D74Eb88036CA65e9F`
**Payout Wallet (SOL):** `3hLpMvUUS685bZz2PzR6vWeA37UrdKq924s7yLMB47eZ`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS handshake timeout reporting to include underlying context errors for clearer failure diagnostics.
  * Preserved special-case certificate-only handling during handshakes.

* **Refactor**
  * Streamlined TLS handshake execution to run once in the background, improving reliability and simplifying timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->