### PR TITLE
fix: make ztls handshake timeout interruptible

### DIFF
--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -332,7 +332,7 @@ func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context)
 	case <-ctx.Done():
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
 	case err := <-errChan:
-		if err == tls.ErrCertsOnly {
+		if errors.Is(err, tls.ErrCertsOnly) {
 			err = nil
 		}
 		return err

--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -323,17 +323,18 @@ func (c *Client) getConfig(hostname, ip, port string, options clients.ConnectOpt
 // tlsHandshakeWithCtx attempts tls handshake with given timeout
 func (c *Client) tlsHandshakeWithTimeout(tlsConn *tls.Conn, ctx context.Context) error {
 	errChan := make(chan error, 1)
-	defer close(errChan)
+
+	go func() {
+		errChan <- tlsConn.Handshake()
+	}()
 
 	select {
 	case <-ctx.Done():
 		return errorutil.NewWithTag("ztls", "timeout while attempting handshake") //nolint
-	case errChan <- tlsConn.Handshake():
+	case err := <-errChan:
+		if err == tls.ErrCertsOnly {
+			err = nil
+		}
+		return err
 	}
-
-	err := <-errChan
-	if err == tls.ErrCertsOnly {
-		err = nil
-	}
-	return err
 }


### PR DESCRIPTION
/claim #819
Closes #819

Handshake() was previously executed inline inside a select, which prevented ctx.Done() from interrupting the TLS handshake and made timeouts ineffective.

This change moves the handshake into a goroutine and properly races ctx.Done() against the handshake result.

### Changes
- Run Handshake() asynchronously in a goroutine
- Properly handle timeout via ctx.Done()
- Remove unnecessary channel close
- Preserve ErrCertsOnly handling

### Notes
A test failure was observed due to a nil pointer dereference after a handshake error in the existing test logic, which appears unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved TLS handshake timeout handling by running the handshake asynchronously and simplifying error flow. This makes connection timeouts more reliable and the handshake path clearer.
  * Maintains existing certificate-only behavior so observable TLS outcomes remain unchanged for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->