### PR TITLE
fix: support comma-separated inputs in -l and stdin

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -440,7 +440,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Split comma-separated inputs to match -u behavior
+				for _, input := range strings.Split(text, ",") {
+					input = strings.TrimSpace(input)
+					if input != "" {
+						r.processInputItem(input, inputs)
+					}
+				}
 			}
 		}
 	}
@@ -449,7 +455,13 @@ func (r *Runner) normalizeAndQueueInputs(inputs chan taskInput) error {
 		for scanner.Scan() {
 			text := scanner.Text()
 			if text != "" {
-				r.processInputItem(text, inputs)
+				// Split comma-separated inputs to match -u behavior
+				for _, input := range strings.Split(text, ",") {
+					input = strings.TrimSpace(input)
+					if input != "" {
+						r.processInputItem(input, inputs)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Problem
The "-u" flag supports comma-separated inputs like:
```
tlsx -u 192.168.1.0/24,192.168.2.0/24
```

However, when using "-l" with a file containing comma-separated values on a single line, it was treated as a single input instead of multiple inputs, causing connection errors.

Fixes #859

## Solution
Split comma-separated values when reading from:
- Input file (-l flag)
- Stdin input

This ensures consistent behavior between "-u" and "-l" flags.

## Changes
- Modified `internal/runner/runner.go`
- Updated `normalizeAndQueueInputs` function to split comma-separated inputs
- Applied the same fix to both file input and stdin input paths

## Testing
- All existing tests pass
- Manually tested with comma-separated CIDR ranges in input file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Input from files and stdin now properly parses comma-separated values with automatic whitespace trimming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->