### PR TITLE
fix(clients): added a nil guard in Convertx509toResponse to match ztls path

### DIFF
--- a/pkg/tlsx/clients/utils.go
+++ b/pkg/tlsx/clients/utils.go
@@ -16,6 +16,9 @@ import (
 )
 
 func Convertx509toResponse(options *Options, hostname string, cert *x509.Certificate, showcert bool) *CertificateResponse {
+	if cert == nil {
+		return nil
+	}
 	domainNames := []string{cert.Subject.CommonName}
 	domainNames = append(domainNames, cert.DNSNames...)
 	response := &CertificateResponse{


### PR DESCRIPTION
## Summary

`Convertx509toResponse` in `pkg/tlsx/clients/utils.go` was missing a nil 
check for the `cert` parameter. The ztls equivalent 
`ConvertCertificateToResponse` in `pkg/tlsx/ztls/utils.go` already guards 
against this:

```go
if cert == nil {
    return nil
}
```

The ctls/openssl path called through `openssl.go:88` passes `resp.AllCerts[0]` 
directly without a nil check, making the nil guard in the callee essential for 
consistent, safe behavior across all TLS connection modes.

## Changes
- Added nil guard at the top of `Convertx509toResponse` in 
  `pkg/tlsx/clients/utils.go`

## Testing
- `go build ./cmd/tlsx/` ✅
- `go test ./pkg/tlsx/clients/...` ✅ all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent crashes in certificate processing scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/tlsx/pull/974)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->