### PR TITLE
fix(ztls,auto): fix nil dereference guards and retry counter logic

### DIFF
--- a/pkg/tlsx/ztls/ztls.go
+++ b/pkg/tlsx/ztls/ztls.go
@@ -163,33 +163,34 @@ func (c *Client) ConnectWithOptions(hostname, ip, port string, options clients.C
 		TLSConnection: "ztls",
 		ServerName:    config.ServerName,
 	}
-	if hl != nil && hl.ServerCertificates != nil {
-		response.CertificateResponse = ConvertCertificateToResponse(c.options, hostname, ParseSimpleTLSCertificate(hl.ServerCertificates.Certificate))
-		if response.CertificateResponse != nil {
-			response.Untrusted = clients.IsZTLSUntrustedCA(hl.ServerCertificates.Chain)
+	if hl != nil {
+		if hl.ServerCertificates != nil {
+			response.CertificateResponse = ConvertCertificateToResponse(c.options, hostname, ParseSimpleTLSCertificate(hl.ServerCertificates.Certificate))
+			if response.CertificateResponse != nil {
+				response.Untrusted = clients.IsZTLSUntrustedCA(hl.ServerCertificates.Chain)
+			}
+			if c.options.TLSChain {
+				for _, cert := range hl.ServerCertificates.Chain {
+					response.Chain = append(response.Chain, ConvertCertificateToResponse(c.options, hostname, ParseSimpleTLSCertificate(cert)))
+				}
+			}
 		}
-	}
-	if hl.ServerHello != nil {
-		response.Version = versionToTLSVersionString[uint16(hl.ServerHello.Version)]
-		response.Cipher = hl.ServerHello.CipherSuite.String()
-	}
-
-	if c.options.TLSChain {
-		for _, cert := range hl.ServerCertificates.Chain {
-			response.Chain = append(response.Chain, ConvertCertificateToResponse(c.options, hostname, ParseSimpleTLSCertificate(cert)))
+		if hl.ServerHello != nil {
+			response.Version = versionToTLSVersionString[uint16(hl.ServerHello.Version)]
+			response.Cipher = hl.ServerHello.CipherSuite.String()
 		}
-	}
-	if c.options.Ja3 {
-		response.Ja3Hash = ja3.GetJa3Hash(hl.ClientHello)
-	}
-	if c.options.Ja3s {
-		response.Ja3sHash = ja3.GetJa3sHash(hl.ServerHello)
-	}
-	if c.options.ClientHello {
-		response.ClientHello = hl.ClientHello
-	}
-	if c.options.ServerHello {
-		response.ServerHello = hl.ServerHello
+		if c.options.Ja3 {
+			response.Ja3Hash = ja3.GetJa3Hash(hl.ClientHello)
+		}
+		if c.options.Ja3s {
+			response.Ja3sHash = ja3.GetJa3sHash(hl.ServerHello)
+		}
+		if c.options.ClientHello {
+			response.ClientHello = hl.ClientHello
+		}
+		if c.options.ServerHello {
+			response.ServerHello = hl.ServerHello
+		}
 	}
 
 	if response.Version != "tls13" {


### PR DESCRIPTION
## Changes

### ztls: nil dereference guards
All `hl` field accesses were moved inside the `hl != nil` check to prevent 
potential nil pointer dereference when the handshake log is unavailable.
`TLSChain` processing is also moved inside the `ServerCertificates` nil 
check to prevent dereference when no certificates are present.

### auto: retry counter fix
The shared `retryCounter` was incremented by all three clients in a single 
loop pass, meaning at default settings (`Retries=1`, forced to 3) each 
client got exactly one attempt and the loop exited — making retries 
effectively impossible. Fixed to use a standard `for i := 0; i < maxRetries` 
loop where each full pass tries all available clients independently.

## Testing
- `go build ./cmd/tlsx/` ✅
- `go test ./pkg/tlsx/clients/...` ✅
- Pre-existing test failure in `TestClientCertRequired` is unrelated to 
  these changes (fails on main too)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced TLS handshake processing with improved null-safety checks to prevent errors when processing certificate data.

* **Refactoring**
  * Adjusted TLS connection retry logic for improved performance, reducing default retry attempts when not explicitly configured.
  * Improved handshake field extraction with better organization and robustness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/tlsx/pull/975)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->