### PR TITLE
fix: honor -resolvers with -scan-all-ips (#976)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -125,6 +125,9 @@ func New(options *clients.Options) (*Runner, error) {
 	dnsOptions := dnsx.DefaultOptions
 	dnsOptions.MaxRetries = runner.options.Retries
 	dnsOptions.Hostsfile = true
+	if len(options.Resolvers) > 0 {
+		dnsOptions.BaseResolvers = options.Resolvers
+	}
 	if sliceutil.Contains(options.IPVersion, "6") {
 		dnsOptions.QuestionTypes = append(dnsOptions.QuestionTypes, dns.TypeAAAA)
 	}


### PR DESCRIPTION
Fixes #976. `-resolvers` was applied to the fastdialer but not to the standalone `dnsx` client used by the `-scan-all-ips` / `-ip-version` resolution path, so queries fell back to the dnsx default pool (1.1.1.1, 8.8.4.4, …).