### PR TITLE
group external dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,15 @@ updates:
       include: "scope"
     labels:
       - "Type: Maintenance"
-    allow:
-      - dependency-name: "github.com/projectdiscovery/*"
     groups:
-      modules:
+      # Internal PD libraries, usually safe to review as a batch
+      projectdiscovery:
         patterns: ["github.com/projectdiscovery/*"]
-    labels:
-      - "Type: Maintenance"
+      # Other packages, separate from PD bumps
+      external:
+        patterns: ["*"]
+        exclude-patterns: ["github.com/projectdiscovery/*"]
+
 #  # Maintain dependencies for GitHub Actions
 #  - package-ecosystem: "github-actions"
 #    directory: "/"


### PR DESCRIPTION
Split gomod Dependabot into two groups: projectdiscovery for github.com/projectdiscovery/* and external for everything else (mirrors httpx #2542). Removes the PD-only allow filter so non-PD bumps land on dev instead of solo security PRs on main.

Closed #986 and #987 as superseded by #988.