### PR TITLE
fix: make certificate revocation checks opt-in again

### DIFF
--- a/cmd/tlsx/main.go
+++ b/cmd/tlsx/main.go
@@ -103,7 +103,7 @@ func readFlags(args ...string) error {
 		flagSet.BoolVarP(&options.Expired, "expired", "ex", false, "display host with host expired certificate"),
 		flagSet.BoolVarP(&options.SelfSigned, "self-signed", "ss", false, "display host with self-signed certificate"),
 		flagSet.BoolVarP(&options.MisMatched, "mismatched", "mm", false, "display host with mismatched certificate"),
-		flagSet.BoolVarP(&options.Revoked, "revoked", "re", false, "display host with revoked certificate"),
+		flagSet.BoolVarP(&options.Revoked, "revoked", "re", false, "display host with revoked certificate (warning: downloads full CRLs/OCSP per cert; high memory/network cost at scale — off by default)"),
 		flagSet.BoolVarP(&options.Untrusted, "untrusted", "un", false, "display host with untrusted certificate"),
 	)
 
@@ -121,7 +121,7 @@ func readFlags(args ...string) error {
 		flagSet.BoolVarP(&options.TLSChain, "tls-chain", "tc", false, "include certificates chain in json output"),
 		flagSet.BoolVarP(&options.VerifyServerCertificate, "verify-cert", "vc", false, "enable verification of server certificate"),
 		flagSet.StringVarP(&options.OpenSSLBinary, "openssl-binary", "ob", "", "OpenSSL Binary Path"),
-		flagSet.BoolVarP(&options.HardFail, "hardfail", "hf", false, "strategy to use if encountered errors while checking revocation status"),
+		flagSet.BoolVarP(&options.HardFail, "hardfail", "hf", false, "treat revocation check errors as revoked (requires -revoked)"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "socks5 proxy to use for tlsx"),
 	)
 

--- a/pkg/tlsx/clients/clients.go
+++ b/pkg/tlsx/clients/clients.go
@@ -122,7 +122,9 @@ type Options struct {
 	Untrusted bool
 	// MisMatched displays if the cert is mismatched
 	MisMatched bool
-	// Revoked displays if the cert is revoked
+	// Revoked enables certificate revocation checks (CRL/OCSP via cfssl).
+	// Off by default: enabling this downloads full CRLs and can consume large
+	// amounts of memory under high concurrency.
 	Revoked bool
 	// HardFail defines Revoke status when there are parse failures or other errors
 	// If HardFail is true then on any error certificate is considered as revoked
@@ -434,9 +436,10 @@ func IsMisMatchedCert(host string, alternativeNames []string) bool {
 	return true
 }
 
-// IsTLSRevoked returns true if the certificate has been revoked or failed to parse
+// IsTLSRevoked returns true if the certificate has been revoked or failed to parse.
+// Revocation checks (CRL/OCSP) only run when options.Revoked is enabled.
 func IsTLSRevoked(options *Options, cert *x509.Certificate) bool {
-	if cert == nil {
+	if !options.Revoked || cert == nil {
 		return options.HardFail
 	}
 	// - false, false: an error was encountered while checking revocations.

--- a/pkg/tlsx/clients/clients_test.go
+++ b/pkg/tlsx/clients/clients_test.go
@@ -234,3 +234,15 @@ func TestIsUntrustedCA(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTLSRevokedSkippedUnlessEnabled(t *testing.T) {
+	// Unreachable CRL URL: if the -revoked guard regresses, this would attempt a network fetch.
+	cert := &x509.Certificate{
+		CRLDistributionPoints: []string{"http://127.0.0.1:1/should-not-fetch.crl"},
+	}
+
+	assert.False(t, IsTLSRevoked(&Options{}, cert))
+	assert.True(t, IsTLSRevoked(&Options{HardFail: true}, cert))
+	assert.False(t, IsTLSRevoked(&Options{Revoked: true}, nil))
+	assert.True(t, IsTLSRevoked(&Options{Revoked: true, HardFail: true}, nil))
+}


### PR DESCRIPTION
## Summary
- Restore the `-revoked` guard from #460 that was accidentally dropped in #395 (`introduce ja3s`), so `cfssl/revoke` CRL/OCSP fetches only run when `-revoked` / `-re` is set.
- Without the guard, every successful handshake downloaded and parsed full CRLs, which can OOM high-concurrency scans (observed ~GB heap from `io.ReadAll` / `x509.ParseCRL` on 4GB hosts).
- Clarify the `-revoked` help text with an explicit memory/network warning, and note that `-hardfail` requires `-revoked`.

## Test plan
- [x] `go test ./pkg/tlsx/clients/ -run TestIsTLSRevokedSkippedUnlessEnabled`
- [x] `tlsx -h` shows warning on `-revoked` / `-hardfail`
- [x] E2B A/B on tiny DO targets (`-c 200 -tls-version -ss -expired -rs`): unpatched peak RSS ~1.9–2.5GB; patched ~70–75MB, no near-OOM


Made with [Cursor](https://cursor.com)